### PR TITLE
add testcase fml reference()

### DIFF
--- a/r5/fml/manifest.xml
+++ b/r5/fml/manifest.xml
@@ -3,4 +3,5 @@
  <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2patgender" source="qr.json" map="qr2pat-gender.map" output="qr2pat-gender-res.json" />
  <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2pathumannametwice" source="qr.json" map="qr2pat-humannametwice.map" output="qr2pat-humannametwice-res.json" />
  <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2pathumannameshared" source="qr.json" map="qr2pat-humannameshared.map" output="qr2pat-humannameshared-res.json" />
+ <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/reference" source="qr.json" map="qr2reference.map" output="qr2reference-res.json" />
 </fml-tests>

--- a/r5/fml/qr.json
+++ b/r5/fml/qr.json
@@ -1,4 +1,5 @@
 {
+  "id" : 12345,
   "resourceType": "QuestionnaireResponse",
   "status": "in-progress",
   "item": [

--- a/r5/fml/qr2reference-res.json
+++ b/r5/fml/qr2reference-res.json
@@ -1,0 +1,8 @@
+{
+  "resourceType" : "Basic",
+  "extension" : [{
+    "valueReference" : {
+      "reference" : "QuestionnaireResponse/12345"
+    }
+  }]
+}

--- a/r5/fml/qr2reference.map
+++ b/r5/fml/qr2reference.map
@@ -1,0 +1,8 @@
+map "http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2reference" = "qr2reference"
+
+uses "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse" alias QuestionnaireResponse as source
+uses "http://hl7.org/fhir/StructureDefinition/Basic" alias Basic as target
+
+group QuestionnaireResponse(source src : QuestionnaireResponse, target tgt : Basic) {
+  src -> tgt.extension as ext, ext.value = create('Reference') as reference, reference.reference = reference(src) "value";
+}


### PR DESCRIPTION
adding a testcase for the FHIR Mapping Language reference function, the reference function is defined as:

return a string that references the provided tree properly



