### PR TITLE
snapshotgen: attributes before elements

### DIFF
--- a/r5/snapshot-generation/logical1-expected.xml
+++ b/r5/snapshot-generation/logical1-expected.xml
@@ -144,6 +144,26 @@
         <map value="n/a"/>
       </mapping>
     </element>
+    <element id="ANY.nullFlavor">
+      <path value="ANY.nullFlavor"/>
+      <representation value="xmlAttr"/>
+      <label value="Exceptional Value Detail"/>
+      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ANY.nullFlavor"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <binding>
+        <strength value="required"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
+      </binding>
+    </element>
     <element id="ANY.extension">
       <path value="ANY.extension"/>
       <slicing>
@@ -191,26 +211,6 @@
         <identity value="rim"/>
         <map value="n/a"/>
       </mapping>
-    </element>
-    <element id="ANY.nullFlavor">
-      <path value="ANY.nullFlavor"/>
-      <representation value="xmlAttr"/>
-      <label value="Exceptional Value Detail"/>
-      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="ANY.nullFlavor"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="code"/>
-      </type>
-      <binding>
-        <strength value="required"/>
-        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
-      </binding>
     </element>
   </snapshot>
   <differential>

--- a/r5/snapshot-generation/logical2-expected.xml
+++ b/r5/snapshot-generation/logical2-expected.xml
@@ -147,6 +147,27 @@
         <map value="n/a"/>
       </mapping>
     </element>
+    <element id="ANY.nullFlavor">
+      <path value="ANY.nullFlavor"/>
+      <representation value="xmlAttr"/>
+      <label value="Exceptional Value Detail"/>
+      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
+      <min value="0"/>
+      <max value="1"/>
+      <base>
+        <path value="ANY.nullFlavor"/>
+        <min value="0"/>
+        <max value="1"/>
+      </base>
+      <type>
+        <code value="code"/>
+      </type>
+      <fixedCode value="UNK"/>
+      <binding>
+        <strength value="required"/>
+        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
+      </binding>
+    </element>
     <element id="ANY.extension">
       <path value="ANY.extension"/>
       <slicing>
@@ -194,27 +215,6 @@
         <identity value="rim"/>
         <map value="n/a"/>
       </mapping>
-    </element>
-    <element id="ANY.nullFlavor">
-      <path value="ANY.nullFlavor"/>
-      <representation value="xmlAttr"/>
-      <label value="Exceptional Value Detail"/>
-      <definition value="If a value is an exceptional value (NULL-value), this specifies in what way and why proper information is missing."/>
-      <min value="0"/>
-      <max value="1"/>
-      <base>
-        <path value="ANY.nullFlavor"/>
-        <min value="0"/>
-        <max value="1"/>
-      </base>
-      <type>
-        <code value="code"/>
-      </type>
-      <fixedCode value="UNK"/>
-      <binding>
-        <strength value="required"/>
-        <valueSet value="http://terminology.hl7.org/ValueSet/v3-NullFlavor"/>
-      </binding>
     </element>
   </snapshot>
   <differential>


### PR DESCRIPTION
this pull requests updates the expected snapshot generation for attributes. attributes are added in the snapshot before the element definitions on the same level, see corresponding pull request https://github.com/hapifhir/org.hl7.fhir.core/pull/121