### PR TITLE
adding pipelines file

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,22 +1,54 @@
-# Maven
-# Build your Java project and run tests with Apache Maven.
-# Add steps that analyze code, save build artifacts, deploy, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/java
-
 trigger:
-- master
+  branches:
+    include:
+      - '*'
+
+# Different users have different machine setups, we run the build three times, on ubuntu, osx, and windows
+strategy:
+  matrix:
+    linux:
+      imageName: "ubuntu-16.04"
+    mac:
+      imageName: "macos-10.14"
+    windows:
+      imageName: "vs2017-win2016"
+  maxParallel: 3
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: $(imageName)
 
 steps:
-- task: Maven@3
-  inputs:
-    mavenPomFile: 'pom.xml'
-    mavenOptions: '-Xmx3072m'
-    javaHomeOption: 'JDKVersion'
-    jdkVersionOption: '1.8'
-    jdkArchitectureOption: 'x64'
-    publishJUnitResults: true
-    testResultsFiles: '**/surefire-reports/TEST-*.xml'
-    goals: 'package'
+  # This task pulls the <version> value from the pom.xml file, so we can set it to the variable $version.
+  - task: PowerShell@2
+    inputs:
+      targetType: 'inline'
+      script: |
+        [xml]$pomXml = Get-Content .\pom.xml
+        # version
+        Write-Host $pomXml.project.version
+        $version=$pomXml.project.version
+        Write-Host "##vso[task.setvariable variable=version]$version"
+
+  # Runs mvn package
+  - task: Maven@3
+    inputs:
+      mavenPomFile: 'pom.xml'
+      mavenOptions: '-Xmx3072m'
+      javaHomeOption: 'JDKVersion'
+      jdkVersionOption: '1.8'
+      jdkArchitectureOption: 'x64'
+      publishJUnitResults: true
+      testResultsFiles: '**/surefire-reports/TEST-*.xml'
+      goals: 'package'
+
+  # Prints out the build version, for debugging purposes
+  - bash: echo Pulled version from pom.xml => $(version)
+
+  # Publishes the fhir-test-cases build artifact to azure, so we can reference it in other builds
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: "$(System.DefaultWorkingDirectory)/target/fhir-test-cases-$(version).jar"
+      artifactName: ProjectAOutput
+
+
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ steps:
     condition: eq(variables.currentImage, 'ubuntu-16.04')
     inputs:
       targetPath: "$(System.DefaultWorkingDirectory)/target/fhir-test-cases-$(version).jar"
-      artifactName: ProjectAOutput
+      artifactName: fhir-test-cases
 
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,9 @@ strategy:
 pool:
   vmImage: $(imageName)
 
+variables:
+  currentImage: $(imageName)
+
 steps:
   # This task pulls the <version> value from the pom.xml file, so we can set it to the variable $version.
   - task: PowerShell@2
@@ -46,6 +49,7 @@ steps:
 
   # Publishes the fhir-test-cases build artifact to azure, so we can reference it in other builds
   - task: PublishPipelineArtifact@1
+    condition: eq(variables.currentImage, 'ubuntu-16.04')
     inputs:
       targetPath: "$(System.DefaultWorkingDirectory)/target/fhir-test-cases-$(version).jar"
       artifactName: ProjectAOutput


### PR DESCRIPTION
Build now runs on Azure Pipelines for all pull requests.

Maven will run build on 3 virtual machines: Windows, Linux, and OSX, before approving for merge.
Build artifact will be saved in Azure for later use with other deployment pipelines. As of right now, it doesn't do anything with it.