### PR TITLE
Add STU3 examples for testing multiple enableWhen conditions

### DIFF
--- a/validator/questionnaire-enablewhen-combination-stu3.json
+++ b/validator/questionnaire-enablewhen-combination-stu3.json
@@ -1,6 +1,6 @@
 {
     "resourceType": "Questionnaire",
-    "url": "http://examples/com/fhir/enableWhenQuestionnaire",
+    "url": "http://examples.com/fhir/enableWhenQuestionnaire",
     "status": "draft",
     "item": [{
             "linkId": "S0",

--- a/validator/questionnaire-enablewhen-combination-stu3.json
+++ b/validator/questionnaire-enablewhen-combination-stu3.json
@@ -1,0 +1,29 @@
+{
+    "resourceType": "Questionnaire",
+    "url": "http://examples/com/fhir/enableWhenQuestionnaire",
+    "status": "draft",
+    "item": [{
+            "linkId": "S0",
+            "type": "boolean"
+        },
+        {
+            "linkId": "S1",
+            "type": "boolean"
+        },
+        {
+            "linkId": "S2",
+            "type": "boolean",
+            "required": true,
+
+            "enableWhen": [{
+                    "question": "S0",
+                    "answerBoolean": true
+                },
+                {
+                    "question": "S1",
+                    "answerBoolean": true
+                }
+            ]
+        }
+    ]
+}

--- a/validator/questionnaire-enablewhen-combination-stu3.json
+++ b/validator/questionnaire-enablewhen-combination-stu3.json
@@ -1,6 +1,6 @@
 {
     "resourceType": "Questionnaire",
-    "url": "http://examples.com/fhir/enableWhenQuestionnaire",
+    "url": "http://example.com/fhir/enableWhenQuestionnaire",
     "status": "draft",
     "item": [{
             "linkId": "S0",

--- a/validator/questionnaireresponse-enablewhen-combination-stu3-disabled-invalid.json
+++ b/validator/questionnaireresponse-enablewhen-combination-stu3-disabled-invalid.json
@@ -1,6 +1,6 @@
 {
     "resourceType": "QuestionnaireResponse",
-    "questionnaire": { "reference": "http://examples/com/fhir/enableWhenQuestionnaire" },
+    "questionnaire": { "reference": "http://examples.com/fhir/enableWhenQuestionnaire" },
     "status": "completed",
     "item": [{
             "linkId": "S0",

--- a/validator/questionnaireresponse-enablewhen-combination-stu3-disabled-invalid.json
+++ b/validator/questionnaireresponse-enablewhen-combination-stu3-disabled-invalid.json
@@ -1,6 +1,6 @@
 {
     "resourceType": "QuestionnaireResponse",
-    "questionnaire": { "reference": "http://examples.com/fhir/enableWhenQuestionnaire" },
+    "questionnaire": { "reference": "http://example.com/fhir/enableWhenQuestionnaire" },
     "status": "completed",
     "item": [{
             "linkId": "S0",

--- a/validator/questionnaireresponse-enablewhen-combination-stu3-disabled-invalid.json
+++ b/validator/questionnaireresponse-enablewhen-combination-stu3-disabled-invalid.json
@@ -1,0 +1,18 @@
+{
+    "resourceType": "QuestionnaireResponse",
+    "questionnaire": { "reference": "http://examples/com/fhir/enableWhenQuestionnaire" },
+    "status": "completed",
+    "item": [{
+            "linkId": "S0",
+            "answer": [{
+                "valueBoolean": true
+            }]
+        },
+        {
+            "linkId": "S1",
+            "answer": [{
+                "valueBoolean": false
+            }]
+        }
+    ]
+}

--- a/validator/questionnaireresponse-enablewhen-combination-stu3-disabled-valid.json
+++ b/validator/questionnaireresponse-enablewhen-combination-stu3-disabled-valid.json
@@ -1,0 +1,18 @@
+{
+    "resourceType": "QuestionnaireResponse",
+    "questionnaire": { "reference": "http://examples/com/fhir/enableWhenQuestionnaire" },
+    "status": "completed",
+    "item": [{
+            "linkId": "S0",
+            "answer": [{
+                "valueBoolean": false
+            }]
+        },
+        {
+            "linkId": "S1",
+            "answer": [{
+                "valueBoolean": false
+            }]
+        }
+    ]
+}

--- a/validator/questionnaireresponse-enablewhen-combination-stu3-disabled-valid.json
+++ b/validator/questionnaireresponse-enablewhen-combination-stu3-disabled-valid.json
@@ -1,6 +1,6 @@
 {
     "resourceType": "QuestionnaireResponse",
-    "questionnaire": { "reference": "http://examples/com/fhir/enableWhenQuestionnaire" },
+    "questionnaire": { "reference": "http://examples.com/fhir/enableWhenQuestionnaire" },
     "status": "completed",
     "item": [{
             "linkId": "S0",

--- a/validator/questionnaireresponse-enablewhen-combination-stu3-disabled-valid.json
+++ b/validator/questionnaireresponse-enablewhen-combination-stu3-disabled-valid.json
@@ -1,6 +1,6 @@
 {
     "resourceType": "QuestionnaireResponse",
-    "questionnaire": { "reference": "http://examples.com/fhir/enableWhenQuestionnaire" },
+    "questionnaire": { "reference": "http://example.com/fhir/enableWhenQuestionnaire" },
     "status": "completed",
     "item": [{
             "linkId": "S0",

--- a/validator/questionnaireresponse-enablewhen-combination-stu3-enabled-invalid.json
+++ b/validator/questionnaireresponse-enablewhen-combination-stu3-enabled-invalid.json
@@ -1,6 +1,6 @@
 {
     "resourceType": "QuestionnaireResponse",
-    "questionnaire": { "reference": "http://examples/com/fhir/enableWhenQuestionnaire" },
+    "questionnaire": { "reference": "http://examples.com/fhir/enableWhenQuestionnaire" },
     "status": "completed",
     "item": [{
             "linkId": "S0",

--- a/validator/questionnaireresponse-enablewhen-combination-stu3-enabled-invalid.json
+++ b/validator/questionnaireresponse-enablewhen-combination-stu3-enabled-invalid.json
@@ -1,0 +1,24 @@
+{
+    "resourceType": "QuestionnaireResponse",
+    "questionnaire": { "reference": "http://examples/com/fhir/enableWhenQuestionnaire" },
+    "status": "completed",
+    "item": [{
+            "linkId": "S0",
+            "answer": [{
+                "valueBoolean": false
+            }]
+        },
+        {
+            "linkId": "S1",
+            "answer": [{
+                "valueBoolean": false
+            }]
+        },
+        {
+            "linkId": "S2",
+            "answer": [{
+                "valueBoolean": false
+            }]
+        }
+    ]
+}

--- a/validator/questionnaireresponse-enablewhen-combination-stu3-enabled-invalid.json
+++ b/validator/questionnaireresponse-enablewhen-combination-stu3-enabled-invalid.json
@@ -1,6 +1,6 @@
 {
     "resourceType": "QuestionnaireResponse",
-    "questionnaire": { "reference": "http://examples.com/fhir/enableWhenQuestionnaire" },
+    "questionnaire": { "reference": "http://example.com/fhir/enableWhenQuestionnaire" },
     "status": "completed",
     "item": [{
             "linkId": "S0",

--- a/validator/questionnaireresponse-enablewhen-combination-stu3-enabled-valid.json
+++ b/validator/questionnaireresponse-enablewhen-combination-stu3-enabled-valid.json
@@ -1,6 +1,6 @@
 {
     "resourceType": "QuestionnaireResponse",
-    "questionnaire": { "reference": "http://examples/com/fhir/enableWhenQuestionnaire" },
+    "questionnaire": { "reference": "http://examples.com/fhir/enableWhenQuestionnaire" },
     "status": "completed",
     "item": [{
             "linkId": "S0",

--- a/validator/questionnaireresponse-enablewhen-combination-stu3-enabled-valid.json
+++ b/validator/questionnaireresponse-enablewhen-combination-stu3-enabled-valid.json
@@ -1,0 +1,24 @@
+{
+    "resourceType": "QuestionnaireResponse",
+    "questionnaire": { "reference": "http://examples/com/fhir/enableWhenQuestionnaire" },
+    "status": "completed",
+    "item": [{
+            "linkId": "S0",
+            "answer": [{
+                "valueBoolean": true
+            }]
+        },
+        {
+            "linkId": "S1",
+            "answer": [{
+                "valueBoolean": true
+            }]
+        },
+        {
+            "linkId": "S2",
+            "answer": [{
+                "valueBoolean": true
+            }]
+        }
+    ]
+}

--- a/validator/questionnaireresponse-enablewhen-combination-stu3-enabled-valid.json
+++ b/validator/questionnaireresponse-enablewhen-combination-stu3-enabled-valid.json
@@ -1,6 +1,6 @@
 {
     "resourceType": "QuestionnaireResponse",
-    "questionnaire": { "reference": "http://examples.com/fhir/enableWhenQuestionnaire" },
+    "questionnaire": { "reference": "http://example.com/fhir/enableWhenQuestionnaire" },
     "status": "completed",
     "item": [{
             "linkId": "S0",


### PR DESCRIPTION
This PR adds some STu3 example for testing the behaviour of `Questionnaire.enableWhen` in STU3. For discussion, see [this Zulip thread](https://chat.fhir.org/#narrow/stream/179177-conformance/topic/Validator.20problem.20for.20compound.20enableWhen.20clause.3F)

* The `Questionnaire` example has two `enableWhen` conditions
* The four `QuestionnaireReponse` examples cover both the enabled and non-enabled case. For each of those, it provides both a valid and invalid examples (as I understand the spec) - filename shows it it is a positive or negative test example.