### PR TITLE
add example with xsi:type

### DIFF
--- a/validator/cda/example-xsi.xml
+++ b/validator/cda/example-xsi.xml
@@ -1,0 +1,8 @@
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:voc="urn:hl7-org:v3/voc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:hl7-org:v3 CDA.xsd">
+	<templateId root="2.16.840.1.113883.3.27.1776"/>
+	<id extension="c266" root="2.16.840.1.113883.19.4"/>
+  <code code="X-34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+    <translation xsi:type="CD" code="X-34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+  </code>
+  <title>Episode Note</title>
+</ClinicalDocument>


### PR DESCRIPTION
this cda example has a code translation included to have an example with an xsi:type attribute.