### PR TITLE
add FHIR Mapping Language conformsTo test

### DIFF
--- a/r5/fml/manifest.xml
+++ b/r5/fml/manifest.xml
@@ -4,4 +4,5 @@
  <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2pathumannametwice" source="qr.json" map="qr2pat-humannametwice.map" output="qr2pat-humannametwice-res.json" />
  <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2pathumannameshared" source="qr.json" map="qr2pat-humannameshared.map" output="qr2pat-humannameshared-res.json" />
  <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/reference" source="qr.json" map="qr2reference.map" output="qr2reference-res.json" />
+ <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2pat-gender-conformstoqr" source="qr.json" map="qr2pat-gender-conformstoqr.map" output="qr2pat-gender-res.json" />
 </fml-tests>

--- a/r5/fml/qr.json
+++ b/r5/fml/qr.json
@@ -1,5 +1,5 @@
 {
-  "id" : 12345,
+  "id" : "12345",
   "resourceType": "QuestionnaireResponse",
   "status": "in-progress",
   "item": [

--- a/r5/fml/qr2pat-gender-conformstoqr.map
+++ b/r5/fml/qr2pat-gender-conformstoqr.map
@@ -1,0 +1,10 @@
+map "http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2pat-gender-conformstoqr" = "qr2pat-gender-conformstoqr"
+
+uses "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse" alias QuestionnaireResponse as source
+uses "http://hl7.org/fhir/StructureDefinition/Patient" alias Patient as target
+
+// we want to check if source conformsTo works
+group QuestionnaireResponse(source src : QuestionnaireResponse, target tgt : Patient) {
+  src where conformsTo('http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse')-> tgt as patient, patient.gender = 'female' "conformsToCheck";
+}
+


### PR DESCRIPTION
added test to check conformsTo function in the FHIR Mapping Language. The example is just that the function is called, there is no useful mapping depending on the outcome of the conformsTo function (the input should be anyway conformant to QuestionnaireResponse).