### PR TITLE
add fhirtocda map tests

### DIFF
--- a/r5/fml/manifest.xml
+++ b/r5/fml/manifest.xml
@@ -5,4 +5,6 @@
  <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2pathumannameshared" source="qr.json" map="qr2pat-humannameshared.map" output="qr2pat-humannameshared-res.json" />
  <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/reference" source="qr.json" map="qr2reference.map" output="qr2reference-res.json" />
  <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2pat-gender-conformstoqr" source="qr.json" map="qr2pat-gender-conformstoqr.map" output="qr2pat-gender-res.json" />
+ <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2cda" source="qr.json" map="qr2cda.map" output="qr2cda-res.xml" />
+ <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2cdaxsi" source="qr.json" map="qr2cdaxsi.map" output="qr2cdaxsi-res.xml" />
 </fml-tests>

--- a/r5/fml/qr2cda-res.xml
+++ b/r5/fml/qr2cda-res.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ClinicalDocument xmlns="urn:hl7-org:v3">
+  <title>Hello CDA</title>
+</ClinicalDocument>

--- a/r5/fml/qr2cda.map
+++ b/r5/fml/qr2cda.map
@@ -1,0 +1,8 @@
+map "http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2cda" = "qr2cda"
+
+uses "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse" alias QuestionnaireResponse as source
+uses "http://hl7.org/fhir/cda/StructureDefinition/ClinicalDocument" alias ClinicalDocument as target
+
+group QuestionnaireResponse(source src : QuestionnaireResponse, target tgt : ClinicalDocument) {
+  src -> tgt.title as title, title.data = 'Hello CDA' "hellocda";
+}

--- a/r5/fml/qr2cdaxsi-res.xml
+++ b/r5/fml/qr2cdaxsi-res.xml
@@ -1,0 +1,5 @@
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <code code="1">
+    <translation xsi:type="CD" code="1" />
+  </code>
+</ClinicalDocument>

--- a/r5/fml/qr2cdaxsi.map
+++ b/r5/fml/qr2cdaxsi.map
@@ -1,0 +1,9 @@
+map "http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2cdaxsi" = "qr2cdaxsi"
+
+uses "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse" alias QuestionnaireResponse as source
+uses "http://hl7.org/fhir/cda/StructureDefinition/ClinicalDocument" alias ClinicalDocument as target
+uses "http://hl7.org/fhir/cda/StructureDefinition/CD" alias CD as target
+
+group QuestionnaireResponse(source src : QuestionnaireResponse, target tgt : ClinicalDocument) {
+  src -> tgt.code as code, code.code = "1", code.translation = create('CD') as translation, translation.code="1" "codes";
+}


### PR DESCRIPTION
This PR adds two new FHIR Mapping Language tests for CDA using the simplified cda model defined in validator/cda:

1) creating a CDA document with a title inside
2) creating a CDA document with a code.translation element, should serialize in CDA with xsi:type   

The corresponding JUnit test (/org.hl7.fhir.validation/src/test/java/org/hl7/fhir/r5/test/FHIRMappingLanguageTests.java) needs to be adapted, that the output can also be xml, this will follow with another PR to the org.hl7.fhir.core project.