### PR TITLE
test case extended for conformsTo on Element

### DIFF
--- a/validator/patient-conform-profile.xml
+++ b/validator/patient-conform-profile.xml
@@ -24,5 +24,15 @@
 					value="conformsTo('http://hl7.org/fhir/StructureDefinition/Patient')" />
 			</constraint>
 		</element>
+		<element id="Patient.maritalStatus">
+			<path value="Patient.maritalStatus" />
+			<constraint>
+					<key value="conformsToCheck" />
+				<severity value="error" />
+				<human value="conformsToCheck" />
+				<expression
+					value="conformsTo('http://hl7.org/fhir/StructureDefinition/CodeableConcept')" />
+			</constraint>
+		</element>
 	</differential>
 </StructureDefinition>


### PR DESCRIPTION
Added a testcase for https://github.com/hapifhir/org.hl7.fhir.core/pull/269. If the test is run without the PR there will be errors on the validation testcase patient-warning-maritalstatus with this profile, because the conformsToCheck cannot be evaluated on maritalStatus (will return an error: Not supported yet). If [PR]( https://github.com/hapifhir/org.hl7.fhir.core/pull/269) is included, the tests are running through.
