### PR TITLE
adding testcase for logical model with no xml ns

### DIFF
--- a/validator/logicalxml-nonamespace-profile.xml
+++ b/validator/logicalxml-nonamespace-profile.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<id value="Header" />
+	<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+		<valueUri value="default"/>
+	</extension>
+	<url value="http://fhir.ch/ig/ch-alis/StructureDefinition/Header" />
+	<version value="0.1.0" />
+	<name value="ChAlisLeistungsschnittstelle" />
+	<title value="CH ALIS Leistungsschnittstelle" />
+	<status value="draft" />
+	<date value="2020-08-13" />
+	<publisher value="ALIS-Connect" />
+	<contact>
+		<name value="ALIS-Connect" />
+		<telecom>
+			<system value="url" />
+			<value value="https://www.alis-connect.ch/" />
+		</telecom>
+	</contact>
+	<description value="Leistungsschnittstelle ALIS Version 4.3" />
+	<jurisdiction>
+		<coding>
+			<system value="urn:iso:std:iso:3166" />
+			<code value="CH" />
+		</coding>
+	</jurisdiction>
+	<fhirVersion value="4.0.1" />
+	<kind value="logical" />
+	<abstract value="false" />
+	<type value="Header" />
+	<baseDefinition value="http://hl7.org/fhir/StructureDefinition/Base" />
+	<derivation value="specialization" />
+	<differential>
+		<element id="Header">
+			<path value="Header" />
+			<min value="1" />
+			<max value="1" />
+		</element>
+		<element id="Header.Version">
+			<path value="Header.Version" />
+			<representation value="xmlAttr" />
+			<short value="Optional according to specification, and required according to XSD" />
+			<min value="0" />
+			<max value="1" />
+			<type>
+				<code value="decimal" />
+			</type>
+		</element>
+		<element id="Header.ReceivingApplication">
+			<path value="Header.ReceivingApplication"/>
+			<min value="1"/>
+			<max value="1"/>
+			<type>
+				<code value="http://fhir.ch/ig/ch-alis/StructureDefinition/Text" />
+			</type>
+		</element>
+	</differential>
+</StructureDefinition>

--- a/validator/logicalxml-nonamespace-textprofile.xml
+++ b/validator/logicalxml-nonamespace-textprofile.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+	<id value="Text" />
+	<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
+		<valueUri value="default"/>
+	</extension>
+	<url value="http://fhir.ch/ig/ch-alis/StructureDefinition/Text" />
+	<version value="0.1.0" />
+	<name value="ChAlisLeistungsschnittstelle" />
+	<title value="CH ALIS Leistungsschnittstelle" />
+	<status value="draft" />
+	<date value="2020-08-13" />
+	<publisher value="ALIS-Connect" />
+	<contact>
+		<name value="ALIS-Connect" />
+		<telecom>
+			<system value="url" />
+			<value value="https://www.alis-connect.ch/" />
+		</telecom>
+	</contact>
+	<description value="Leistungsschnittstelle ALIS Version 4.3" />
+	<jurisdiction>
+		<coding>
+			<system value="urn:iso:std:iso:3166" />
+			<code value="CH" />
+		</coding>
+	</jurisdiction>
+	<fhirVersion value="4.0.1" />
+	<kind value="logical" />
+	<abstract value="false" />
+	<type value="Text" />
+	<baseDefinition value="http://hl7.org/fhir/StructureDefinition/Base" />
+	<derivation value="specialization" />
+	<differential>
+		<element id="Text">
+			<path value="Text"/>
+			<min value="1"/>
+			<max value="1"/>
+		</element>
+		<element id="Text.data">
+			<path value="Text.data"/>
+			<representation value="xmlText" />
+			<min value="1"/>
+			<max value="1"/>
+			<type>
+				<code value="string"/>
+			</type>
+		</element>
+	</differential>
+</StructureDefinition>

--- a/validator/logicalxml-nonamespace.xml
+++ b/validator/logicalxml-nonamespace.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<Header Version="4.3">
+    <ReceivingApplication>1.2.3</ReceivingApplication>
+</Header>

--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -4342,6 +4342,28 @@
         "output": ["ERROR: Observation.code.coding[0]: The code system reference http://build.fhir.org/assert-response-code-types is wrong - the code system reference cannot be a reference to build.fhir.org. This may be the correct reference: http://hl7.org/fhir/assert-response-code-types", 
                    "ERROR: Observation.value.ofType(CodeableConcept).coding[0]: The code system reference http://hl7.org/fhir/R4/codesystem-assert-response-code-types.html is wrong - the code system reference cannot be to an HTML page. This may be the correct reference: http://hl7.org/fhir/assert-response-code-types"]
       }
+    },
+    "logicalxml-nonamespace.xml": {
+      "java": {
+      },
+      "allowed-extension-domain": "http://fhir.ch/ig/ch-alis/StructureDefinition/",
+      "errorCount": 0,
+      "logical": {
+        "supporting": [
+          "logicalxml-nonamespace-profile.xml",
+          "logicalxml-nonamespace-textprofile.xml"
+        ],
+        "expressions": [
+          "Header.Version \u003d \u00274.3\u0027",
+          "Header.ReceivingApplication.data \u003d \u00271.2.3\u0027"
+        ],
+        "java": {
+          "errorCount": 0,
+          "warningCount": 0,
+          "infoCount" : 0,
+          "output": []
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
we need to work with older xml files which are living in the standard xml namespace and have no default namespace. added are an example file and profiles to describe the logical model. a PR will follow to support namespace less xml.