### PR TITLE
noNamespace instead of default

### DIFF
--- a/validator/logicalxml-nonamespace-profile.xml
+++ b/validator/logicalxml-nonamespace-profile.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
 	<id value="Header" />
 	<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
-		<valueUri value="default"/>
+		<valueUri value="noNamespace"/>
 	</extension>
 	<url value="http://fhir.ch/ig/ch-alis/StructureDefinition/Header" />
 	<version value="0.1.0" />

--- a/validator/logicalxml-nonamespace-textprofile.xml
+++ b/validator/logicalxml-nonamespace-textprofile.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
 	<id value="Text" />
 	<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-namespace">
-		<valueUri value="default"/>
+		<valueUri value="noNamespace"/>
 	</extension>
 	<url value="http://fhir.ch/ig/ch-alis/StructureDefinition/Text" />
 	<version value="0.1.0" />


### PR DESCRIPTION
[FHIR-28413](https://jira.hl7.org/browse/FHIR-28413) Additional documentation for extension for namespace definition

Resolution of FHIR-28413 was to use noNamespace in the StructureDefinition instead of default. 

This PR changes the [exisition behavior](https://github.com/hapifhir/org.hl7.fhir.core/pull/321) to the resolution for the testcase.