### PR TITLE
Add basic tests for FHIRPath matches()

### DIFF
--- a/r5/fhirpath/tests-fhir-r5.xml
+++ b/r5/fhirpath/tests-fhir-r5.xml
@@ -663,6 +663,14 @@ Any text enclosed within is ignored
 		<test name="testContainsString7" inputfile="patient-example.xml"><expression>'12345'.contains('') = true</expression><output type="boolean">true</output></test>
 	</group>
 
+	<group name="testMatches">
+		<test name="testMatchesCaseSensitive1"><expression>'FHIR'.matches('FHIR')</expression><output type="boolean">true</output></test>
+		<test name="testMatchesCaseSensitive2"><expression>'FHIR'.matches('fhir')</expression><output type="boolean">false</output></test>
+		<test name="testMatchesSingleLineMode1"><expression>'A
+			B'.matches('A.*B')</expression><output type="boolean">true</output></test>
+		<test name="testMatchesUnicodeCharacters"><expression>'🔥🔥🔥'.matches('🔥+')</expression><output type="boolean">true</output></test>
+	</group>
+
 	<group name="testLength">
 		<test name="testLength1" inputfile="patient-example.xml"><expression>'123456'.length() = 6</expression><output type="boolean">true</output></test>
 		<test name="testLength2" inputfile="patient-example.xml"><expression>'12345'.length() = 5</expression><output type="boolean">true</output></test>


### PR DESCRIPTION
Basic test cases for FHIRPath `matches()`:
* Test if 'single line' mode is applied
* Test if case sensitivity is honored
* Test for unicode handling

The first test case is in relation to https://github.com/hapifhir/org.hl7.fhir.core/pull/498