### PR TITLE
Adding TypeSubtypeSlicing test cases

### DIFF
--- a/validator/TypeSubtypeSlicing1.json
+++ b/validator/TypeSubtypeSlicing1.json
@@ -1,0 +1,100 @@
+{
+  "resourceType": "Observation",
+  "id": "TypeSubtypeSlicing1",
+  "meta": {
+    "profile": [
+      "http://touchstone.aegis.net/touchstone/fhir/TS-Custom-Bundle/StructureDefinition/TypeSubtypeSlicingstructuredef"
+    ]
+  },
+  "referenceRange": [
+    {
+      "type": {
+        "coding": [
+          {
+            "code": "normal",
+            "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning"
+          }
+        ]
+      },
+      "appliesTo": [
+        {
+          "coding": [
+            {
+              "code": "2036-2",
+              "system": "http://terminology.hl7.org/CodeSystem/v3-Race"
+            }
+          ]
+        }
+      ],
+      "low": {
+        "value": 1,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      },
+      "high": {
+        "value": 10,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      }
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "code": "normal",
+            "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning"
+          }
+        ]
+      },
+      "appliesTo": [
+        {
+          "coding": [
+            {
+              "code": "2038-8",
+              "system": "http://terminology.hl7.org/CodeSystem/v3-Race"
+            }
+          ]
+        }
+      ],
+      "low": {
+        "value": 1,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      },
+      "high": {
+        "value": 10,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      }
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "code": "treatment",
+            "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning"
+          }
+        ]
+      },
+      "low": {
+        "value": 1,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      },
+      "high": {
+        "value": 10,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      }
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "code": "10155-0",
+        "system": "http://loinc.org"
+      }
+    ]
+  },
+  "status": "final"
+}

--- a/validator/TypeSubtypeSlicing2.json
+++ b/validator/TypeSubtypeSlicing2.json
@@ -1,0 +1,75 @@
+{
+  "resourceType": "Observation",
+  "id": "TypeSubtypeSlicing2",
+  "code": {
+    "coding": [
+      {
+        "code": "10155-0",
+        "system": "http://loinc.org"
+      }
+    ]
+  },
+  "status": "final",
+  "referenceRange": [
+    {
+      "type": {
+        "coding": [
+          {
+            "code": "normal",
+            "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning"
+          }
+        ]
+      },
+      "low": {
+        "value": 1,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      },
+      "high": {
+        "value": 10,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      }
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "code": "normal",
+            "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning"
+          }
+        ]
+      },
+      "low": {
+        "value": 1,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      },
+      "high": {
+        "value": 10,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      }
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "code": "treatment",
+            "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning"
+          }
+        ]
+      },
+      "low": {
+        "value": 1,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      },
+      "high": {
+        "value": 10,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      }
+    }
+  ]
+}

--- a/validator/TypeSubtypeSlicing3.json
+++ b/validator/TypeSubtypeSlicing3.json
@@ -1,0 +1,105 @@
+{
+  "resourceType": "Observation",
+  "id": "TypeSubtypeSlicing3",
+  "code": {
+    "coding": [
+      {
+        "code": "10155-0",
+        "system": "http://loinc.org"
+      }
+    ]
+  },
+  "status": "final",
+  "referenceRange": [
+    {
+      "type": {
+        "coding": [
+          {
+            "code": "normal",
+            "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning"
+          }
+        ]
+      },
+      "appliesTo": [
+        {
+          "coding": [
+            {
+              "code": "2106-3",
+              "system": "http://terminology.hl7.org/CodeSystem/v3-Race"
+            }
+          ]
+        }
+      ],
+      "low": {
+        "value": 1,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      },
+      "high": {
+        "value": 10,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      }
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "code": "treatment",
+            "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning"
+          }
+        ]
+      },
+      "appliesTo": [
+        {
+          "coding": [
+            {
+              "code": "2036-2",
+              "system": "http://terminology.hl7.org/CodeSystem/v3-Race"
+            }
+          ]
+        }
+      ],
+      "low": {
+        "value": 1,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      },
+      "high": {
+        "value": 10,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      }
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "code": "treatment",
+            "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning"
+          }
+        ]
+      },
+      "appliesTo": [
+        {
+          "coding": [
+            {
+              "code": "2038-8",
+              "system": "http://terminology.hl7.org/CodeSystem/v3-Race"
+            }
+          ]
+        }
+      ],
+      "low": {
+        "value": 1,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      },
+      "high": {
+        "value": 10,
+        "code": "J/C",
+        "system": "http://unitsofmeasure.org"
+      }
+    }
+  ]
+}

--- a/validator/TypeSubtypeSlicingstructuredef.json
+++ b/validator/TypeSubtypeSlicingstructuredef.json
@@ -11,7 +11,7 @@
       "valueCode": "patient"
     }
   ],
-  "url": "http://touchstone.aegis.net/touchstone/fhir/TS-Custom-Bundle/StructureDefinition/TypeSubtypeSlicingstructuredef",
+  "url": "http://example.org/fhir/StructureDefinition/TypeSubtypeSlicingstructuredef",
   "version": "4.0.1",
   "name": "TypeSubtypeSlicingstructuredef",
   "title": "TypeSubtypeSlicingstructuredef",

--- a/validator/TypeSubtypeSlicingstructuredef.json
+++ b/validator/TypeSubtypeSlicingstructuredef.json
@@ -1,0 +1,167 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "TypeSubtypeSlicingstructuredef",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-category",
+      "valueString": "Clinical.Diagnostics"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-security-category",
+      "valueCode": "patient"
+    }
+  ],
+  "url": "http://touchstone.aegis.net/touchstone/fhir/TS-Custom-Bundle/StructureDefinition/TypeSubtypeSlicingstructuredef",
+  "version": "4.0.1",
+  "name": "TypeSubtypeSlicingstructuredef",
+  "title": "TypeSubtypeSlicingstructuredef",
+  "status": "active",
+  "description": "TypeSubtypeSlicingstructuredef profile for testing type/subtype validation where subtype is not required for all slices.",
+  "fhirVersion": "4.0.1",
+  "mapping": [
+    {
+      "identity": "workflow",
+      "uri": "http://hl7.org/fhir/workflow",
+      "name": "Workflow Pattern"
+    },
+    {
+      "identity": "sct-concept",
+      "uri": "http://snomed.info/conceptdomain",
+      "name": "SNOMED CT Concept Domain Binding"
+    },
+    {
+      "identity": "v2",
+      "uri": "http://hl7.org/v2",
+      "name": "HL7 v2 Mapping"
+    },
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    },
+    {
+      "identity": "w5",
+      "uri": "http://hl7.org/fhir/fivews",
+      "name": "FiveWs Pattern Mapping"
+    },
+    {
+      "identity": "sct-attr",
+      "uri": "http://snomed.org/attributebinding",
+      "name": "SNOMED CT Attribute Binding"
+    }
+  ],
+  "kind": "resource",
+  "abstract": false,
+  "type": "Observation",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Observation.referenceRange",
+        "path": "Observation.referenceRange",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "pattern",
+              "path": "type"
+            },
+            {
+              "type": "pattern",
+              "path": "appliesTo"
+            }
+          ],
+          "rules": "open",
+          "description": "Slicing for testing type/subtype validation where subtype is not required for all slices."
+        },
+        "min": 3
+      },
+      {
+        "id": "Observation.referenceRange:Slice1",
+        "path": "Observation.referenceRange",
+        "sliceName": "Slice1",
+        "min": 1,
+        "max": "1"
+      },
+      {
+        "id": "Observation.referenceRange:Slice1.type",
+        "path": "Observation.referenceRange.type",
+        "min": 1,
+        "patternCodeableConcept": {
+          "coding": [
+            {
+              "code": "normal",
+              "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Observation.referenceRange:Slice1.appliesTo",
+        "path": "Observation.referenceRange.appliesTo",
+        "min": 1,
+        "patternCodeableConcept": {
+          "coding": [
+            {
+              "code": "2036-2",
+              "system": "http://terminology.hl7.org/CodeSystem/v3-Race"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Observation.referenceRange:Slice2",
+        "path": "Observation.referenceRange",
+        "sliceName": "Slice2",
+        "min": 1,
+        "max": "1"
+      },
+      {
+        "id": "Observation.referenceRange:Slice2.type",
+        "path": "Observation.referenceRange.type",
+        "min": 1,
+        "patternCodeableConcept": {
+          "coding": [
+            {
+              "code": "normal",
+              "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Observation.referenceRange:Slice2.appliesTo",
+        "path": "Observation.referenceRange.appliesTo",
+        "min": 1,
+        "patternCodeableConcept": {
+          "coding": [
+            {
+              "code": "2038-8",
+              "system": "http://terminology.hl7.org/CodeSystem/v3-Race"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Observation.referenceRange:Slice3",
+        "path": "Observation.referenceRange",
+        "sliceName": "Slice3",
+        "min": 1,
+        "max": "1"
+      },
+      {
+        "id": "Observation.referenceRange:Slice3.type",
+        "path": "Observation.referenceRange.type",
+        "min": 1,
+        "patternCodeableConcept": {
+          "coding": [
+            {
+              "code": "treatment",
+              "system": "http://terminology.hl7.org/CodeSystem/referencerange-meaning"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -9520,6 +9520,63 @@
           "ERROR: ValueSet.url: UUIDs must be valid (Error at index 0 in: \":6a2ee390\")"
         ]
       }
+    },
+    {
+      "name" : "type-subtype-slicing1",
+      "file" : "type-subtype-slicing1.json",
+      "version" : "4.0",
+      "profiles": [
+        "type-subtype-slicing-structuredef.json"
+      ],
+      "profile": {
+        "source": "type-subtype-slicing-structuredef.json",
+        "java": {
+          "errorCount": 0,
+          "warningCount" : 0
+        }
+      },
+      "java": {
+        "errorCount": 0,
+        "warningCount" : 0
+      }
+    },
+    {
+      "name" : "type-subtype-slicing2",
+      "file" : "type-subtype-slicing2.json",
+      "version" : "4.0",
+      "profiles": [
+        "type-subtype-slicing-structuredef.json"
+      ],
+      "profile": {
+        "source": "type-subtype-slicing-structuredef.json",
+        "java": {
+          "errorCount": 2,
+          "warningCount" : 0
+        }
+      },
+      "java": {
+        "errorCount": 0,
+        "warningCount" : 0
+      }
+    },
+    {
+      "name" : "type-subtype-slicing3",
+      "file" : "type-subtype-slicing3.json",
+      "version" : "4.0",
+      "profiles": [
+        "type-subtype-slicing-structuredef.json"
+      ],
+      "profile": {
+        "source": "type-subtype-slicing-structuredef.json",
+        "java": {
+          "errorCount": 3,
+          "warningCount" : 0
+        }
+      },
+      "java": {
+        "errorCount": 0,
+        "warningCount" : 0
+      }
     }
   ]
 }


### PR DESCRIPTION
Validator seems to not understand slicing with multiple discriminators when at least one of those values is not used in at least one slice. 
These changes add test cases against a profile that defines 3 required slices, two with the same value for one of the discriminators that can only be told apart with the 2nd discriminator, and another which does not require a value from the 2nd discriminators
the three test cases are then one with all three slices.
one that is missing values for the 2nd discriminator but matches all three slices on the first discriminator; to make sure the validator is properly evaluating the 2nd discriminator.
one that is matching the 2nd discriminator for the two slices that use it, but has the wrong value in the 1st discriminator so that none of the slices are matching
