### PR TITLE
bundle-conforms-to misses error (#676)

### DIFF
--- a/validator/bundle-conformsto-bundle.json
+++ b/validator/bundle-conformsto-bundle.json
@@ -1,0 +1,84 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "BundleConformsTo",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-category",
+      "valueString": "Foundation.Other"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-security-category",
+      "valueCode": "not-classified"
+    }
+  ],
+  "url": "http://ahdis.ch/ig/bundleconformsto/StructureDefinition/BundleConformsTo",
+  "version": "0.1.0",
+  "name": "BundleConformsTo",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "mapping": [
+    {
+      "identity": "v2",
+      "uri": "http://hl7.org/v2",
+      "name": "HL7 v2 Mapping"
+    },
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    },
+    {
+      "identity": "cda",
+      "uri": "http://hl7.org/v3/cda",
+      "name": "CDA (R2)"
+    },
+    {
+      "identity": "w5",
+      "uri": "http://hl7.org/fhir/fivews",
+      "name": "FiveWs Pattern Mapping"
+    }
+  ],
+  "kind": "resource",
+  "abstract": false,
+  "type": "Bundle",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Bundle",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Bundle.entry",
+        "path": "Bundle.entry",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "profile",
+              "path": "resource"
+            }
+          ],
+          "rules": "open"
+        },
+        "min": 1
+      },
+      {
+        "id": "Bundle.entry:Composition",
+        "path": "Bundle.entry",
+        "sliceName": "Composition",
+        "min": 1,
+        "max": "1"
+      },
+      {
+        "id": "Bundle.entry:Composition.resource",
+        "path": "Bundle.entry.resource",
+        "min": 1,
+        "type": [
+          {
+            "code": "Composition",
+            "profile": [
+              "http://ahdis.ch/ig/bundleconformsto/StructureDefinition/BundleComposition"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/validator/bundle-conformsto-composition.json
+++ b/validator/bundle-conformsto-composition.json
@@ -1,0 +1,67 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "BundleComposition",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-category",
+      "valueString": "Foundation.Documents"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-security-category",
+      "valueCode": "not-classified"
+    }
+  ],
+  "url": "http://ahdis.ch/ig/bundleconformsto/StructureDefinition/BundleComposition",
+  "version": "0.1.0",
+  "name": "BundleComposition",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "mapping": [
+    {
+      "identity": "workflow",
+      "uri": "http://hl7.org/fhir/workflow",
+      "name": "Workflow Pattern"
+    },
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    },
+    {
+      "identity": "cda",
+      "uri": "http://hl7.org/v3/cda",
+      "name": "CDA (R2)"
+    },
+    {
+      "identity": "fhirdocumentreference",
+      "uri": "http://hl7.org/fhir/documentreference",
+      "name": "FHIR DocumentReference"
+    },
+    {
+      "identity": "w5",
+      "uri": "http://hl7.org/fhir/fivews",
+      "name": "FiveWs Pattern Mapping"
+    }
+  ],
+  "kind": "resource",
+  "abstract": false,
+  "type": "Composition",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Composition",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Composition.subject",
+        "path": "Composition.subject",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://ahdis.ch/ig/bundleconformsto/StructureDefinition/BundlePatient"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/validator/bundle-conformsto-patient.json
+++ b/validator/bundle-conformsto-patient.json
@@ -1,0 +1,62 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "BundlePatient",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-category",
+      "valueString": "Base.Individuals"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-security-category",
+      "valueCode": "patient"
+    }
+  ],
+  "url": "http://ahdis.ch/ig/bundleconformsto/StructureDefinition/BundlePatient",
+  "version": "0.1.0",
+  "name": "BundlePatient",
+  "status": "active",
+  "description": "Patient with one identifer",
+  "fhirVersion": "4.0.1",
+  "mapping": [
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    },
+    {
+      "identity": "cda",
+      "uri": "http://hl7.org/v3/cda",
+      "name": "CDA (R2)"
+    },
+    {
+      "identity": "w5",
+      "uri": "http://hl7.org/fhir/fivews",
+      "name": "FiveWs Pattern Mapping"
+    },
+    {
+      "identity": "v2",
+      "uri": "http://hl7.org/v2",
+      "name": "HL7 v2 Mapping"
+    },
+    {
+      "identity": "loinc",
+      "uri": "http://loinc.org",
+      "name": "LOINC code for the element"
+    }
+  ],
+  "kind": "resource",
+  "abstract": false,
+  "type": "Patient",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Patient.identifier",
+        "path": "Patient.identifier",
+        "min": 1,
+        "mustSupport": true
+      }
+    ]
+  }
+}

--- a/validator/bundle-conformsto.json
+++ b/validator/bundle-conformsto.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "Bundle",
+  "id": "medicationcard",
+  "meta": {
+    "profile": [
+      "http://ahdis.ch/ig/bundleconformsto/StructureDefinition/BundleConformsTo"
+    ]
+  },
+  "identifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:uuid:395f6185-1a1d-4c3f-83ba-05e7148cd46d"
+  },
+  "timestamp": "2021-09-22T14:08:25.5498368+02:00",
+  "type": "document",
+  "entry": [
+    {
+      "fullUrl": "http://testklinik.ch/Composition/63928c0f-9e93-4610-b589-aea68ad18e3e",
+      "resource": {
+        "resourceType": "Composition",
+        "id": "63928c0f-9e93-4610-b589-aea68ad18e3e",
+        "identifier": {
+          "system": "urn:ietf:rfc:3986",
+          "value": "urn:uuid:395f6185-1a1d-4c3f-83ba-05e7148cd46d"
+        },
+        "status": "final",
+        "type": {
+          "coding": [
+            {
+              "code": "721912009",
+              "system": "http://snomed.info/sct",
+              "display": "Medication summary document (record artifact)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/65788"
+        },
+        "date": "2021-09-22T14:08:25.5498368+02:00",
+        "author": [
+          {
+            "reference": "Patient/65788"
+          }
+        ],
+        "title": "Medikationsplan"
+      }
+    },
+    {
+      "fullUrl": "http://testklinik.ch/Patient/65788",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "65788",
+        "name": [
+          {
+            "family": "Wegmüller",
+            "given": [
+              "Monika"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -9632,6 +9632,21 @@
           "ERROR: Condition: dom-3: 'If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource' 'If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource' ( (unmatched: 12345678901234567890123456789012345678901234567890123456789012345))",
         ]
       }
+    },
+    {
+      "name": "bundle-conformsto",
+      "file": "bundle-conformsto.json",
+      "version" : "4.0",
+      "profiles" : [ "bundle-conformsto-patient.json", "bundle-conformsto-bundle.json", "bundle-conformsto-composition.json" ],
+      "java": {
+        "errorCount": 1,
+        "output" : [
+          "ERROR: Bundle.entry:Composition: minimum required = 1, but only found 0 (from http://ahdis.ch/ig/bundleconformsto/StructureDefinition/BundleConformsTo)",
+          "INFORMATION: Bundle.entry[0].resource.ofType(Composition).type: None of the codings provided are in the value set 'FHIR Document Type Codes' (http://hl7.org/fhir/ValueSet/doc-typecodes), and a coding is recommended to come from this value set) (codes = http://snomed.info/sct#721912009)",
+          "INFORMATION: Bundle.entry[1]: This element does not match any known slice defined in the profile http://ahdis.ch/ig/bundleconformsto/StructureDefinition/BundleConformsTo",
+          "INFORMATION: Bundle.entry[0].resource.type: None of the codings provided are in the value set 'FHIR Document Type Codes' (http://hl7.org/fhir/ValueSet/doc-typecodes), and a coding is recommended to come from this value set) (codes = http://snomed.info/sct#721912009)"
+       ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Testcase for illustrating the difference on conformsTo handling within IGPublisher and Validator:

1. Created an IG which illustrates the problem: [BundleConformsTo]( http://build.fhir.org/ig/oliveregger/BundleConformsTo/branches/master/qa.html#_scratch_ig-build-temp-DWHJ33_repo_fsh-generated_resources_Bundle-medicationcard) defines a Document with a Composition.subject to be a patient and the the patient needs to have an identifier. The example bundle provides is missing the patient.identifier and the IG Publisher is correctly providing the error message "ERROR: Bundle.entry:Composition: minimum required = 1, but only found 0 (from http://ahdis.ch/ig/bundleconformsto/StructureDefinition/BundleConformsTo)" 

2. Added the example and StructureDefintions and example to this PR, test is called bundle-conformsto and is failing because the error is not raised

3. Using the [PR](https://github.com/hapifhir/org.hl7.fhir.core/pull/676) the test runs through successfully, the error is raised as in 1.