### PR TITLE
Add test for FHIR Mapping evaluate

### DIFF
--- a/r5/fml/manifest.xml
+++ b/r5/fml/manifest.xml
@@ -7,4 +7,5 @@
  <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2pat-gender-conformstoqr" source="qr.json" map="qr2pat-gender-conformstoqr.map" output="qr2pat-gender-res.json" />
  <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2cda" source="qr.json" map="qr2cda.map" output="qr2cda-res.xml" />
  <test name="http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2cdaxsi" source="qr.json" map="qr2cdaxsi.map" output="qr2cdaxsi-res.xml" />
+ <test name="https://github.com/hapifhir/org.hl7.fhir.core/issues/802" source="qr.json" map="qr2cda-eval.map" output="qr2cda-eval-res.xml" />
 </fml-tests>

--- a/r5/fml/qr2cda-eval-res.xml
+++ b/r5/fml/qr2cda-eval-res.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ClinicalDocument xmlns="urn:hl7-org:v3-test">
+  <title>Hello CDA</title>
+</ClinicalDocument>

--- a/r5/fml/qr2cda-eval.map
+++ b/r5/fml/qr2cda-eval.map
@@ -1,0 +1,8 @@
+map "http://github.com/hapifhir/org.hl7.fhir.core/org.hl7.fhir.r4.tests/qr2cda" = "qr2cda"
+
+uses "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse" alias QuestionnaireResponse as source
+uses "http://hl7.org/fhir/cdatest/StructureDefinition/ClinicalDocument" alias ClinicalDocument as target
+
+group QuestionnaireResponse(source src : QuestionnaireResponse, target tgt : ClinicalDocument) {
+  src -> tgt.title as title, title.data= evaluate(src, iif(src.is(QuestionnaireResponse),"Hello CDA","badbadbad")) "eval";
+}


### PR DESCRIPTION
Creates a test for the use of the evaluate transform.

This was created in order to provide a working example for evaluating whether or not https://github.com/hapifhir/org.hl7.fhir.core/issues/802 is a bug or not. If this test is valid, it should be merged.