### PR TITLE
Update loinc and snomed versions for failing tests

### DIFF
--- a/validator/code-wrong-display.xml
+++ b/validator/code-wrong-display.xml
@@ -2,7 +2,7 @@
   <code>
     <coding>
       <system value="http://snomed.info/sct"/>
-      <version value="http://snomed.info/sct/731000124108/version/20210901"/>
+      <version value="http://snomed.info/sct/11000172109/version/20210915"/>
       <code value="132037003"/>
       <display value="Pineywoods pig breed. Not."/>
     </coding>

--- a/validator/demo-example-2.xml
+++ b/validator/demo-example-2.xml
@@ -7,7 +7,7 @@
   <type>
     <coding>
       <system value="http://loinc.org"/>
-      <version value="2.71"/>
+      <version value="2.72"/>
       <code value="56445-0"/>
       <display value="Medication summary Doc"/>
     </coding>
@@ -26,7 +26,7 @@
     <code>
       <coding>
         <system value="http://loinc.org"/>
-        <version value="2.71"/>
+        <version value="2.72"/>
         <code value="48765-2"/>
         <display value="Allergies and adverse reactions"/>
       </coding>

--- a/validator/ext_context1_bundle.xml
+++ b/validator/ext_context1_bundle.xml
@@ -22,7 +22,7 @@
 					<code>
 						<coding>
 							<system value="http://loinc.org" />
-							<version value="2.71" />
+							<version value="2.72" />
 							<code value="57852-6" />
 							<display value="Problem list Narrative - Reported" />
 						</coding>
@@ -83,7 +83,7 @@
 						<valueCodeableConcept>
 							<coding>
 								<system value="http://snomed.info/sct" />
-								<version value="http://snomed.info/sct/900000000000207008/version/20210731" />
+								<version value="http://snomed.info/sct/11000172109/version/20210915" />
 								<code value="271872005" />
 								<display value="Old age (qualifier value)">
 									<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Terminology_German">
@@ -101,7 +101,7 @@
 						<valueCodeableConcept>
 							<coding>
 								<system value="http://snomed.info/sct" />
-								<version value="http://snomed.info/sct/900000000000207008/version/20210731" />
+								<version value="http://snomed.info/sct/11000172109/version/20210915" />
 								<code value="271872005" />
 								<display value="Old age (qualifier value)">
 									<extension url="https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Terminology_German">

--- a/validator/snomed-ca.json
+++ b/validator/snomed-ca.json
@@ -6,7 +6,7 @@
   "vaccineCode" : {
     "coding": [{
       "system": "http://snomed.info/sct",
-      "version": "http://snomed.info/sct/20611000087101/version/20210930",
+      "version": "http://snomed.info/sct/11000146104/version/20210930",
       "code": "36989005",
       "display": "Mumps"
     }]


### PR DESCRIPTION
The cached responses for ValidationTests in org.hl7.fhir.core contained older versions of responses from the tx server.

When the cache was cleared and rebuilt using the following commands, it resulted in ValidationTests failures.

```shell
mvn clean -Dfhir.txcache.clean=true
mvn test -Dfhir.txcache.rebuild=true -U
```

The root cause appears to be the use of loinc and snomed versions no longer supported. This PR updates those to the next available versions chronologically, which fixes the failing tests and correctly regenerates the cache contents.