### PR TITLE
Fix manifest JSON

### DIFF
--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -9634,7 +9634,7 @@
         "errorCount": 1,
         "warningCount": 0,
         "output" : [
-          "ERROR: Condition: dom-3: 'If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource' 'If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource' ( (unmatched: 12345678901234567890123456789012345678901234567890123456789012345))",
+          "ERROR: Condition: dom-3: 'If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource' 'If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource' ( (unmatched: 12345678901234567890123456789012345678901234567890123456789012345))"
         ]
       }
     },


### PR DESCRIPTION
The manifest JSON did not parse correctly, due to an extraneous trailing comma.