### PR TITLE
Add test cases for SVG processing in XHTML

### DIFF
--- a/xhtml/namespaced-non-root-svg.html
+++ b/xhtml/namespaced-non-root-svg.html
@@ -1,0 +1,12 @@
+<div xmlns="http://www.w3.org/1999/xhtml" xmlns:svg="http://www.w3.org/2000/svg">
+    <svg:svg contentScriptType="application/ecmascript"
+         contentStyleType="text/css"
+         width="300px" height="200px"
+         xmlns:xlink="http://www.w3.org/1999/xlink" zoomAndPan="magnify">
+        <svg:a href="#human" target="_top" title="#human"
+           xlink:actuate="onRequest" xlink:href="#human"
+           xlink:show="new" xlink:title="#human" xlink:type="simple">
+            <svg:circle cx="150" cy="100" r="50" fill="#ff0000" />
+        </svg:a>
+    </svg:svg>
+</div>

--- a/xhtml/non-root-svg.html
+++ b/xhtml/non-root-svg.html
@@ -1,0 +1,13 @@
+<div xmlns="http://www.w3.org/1999/xhtml">
+    <svg contentScriptType="application/ecmascript"
+         contentStyleType="text/css"
+         width="300px" height="200px"
+         xmlns="http://www.w3.org/2000/svg"
+         xmlns:xlink="http://www.w3.org/1999/xlink" zoomAndPan="magnify">
+        <a href="#human" target="_top" title="#human"
+           xlink:actuate="onRequest" xlink:href="#human"
+           xlink:show="new" xlink:title="#human" xlink:type="simple">
+            <circle cx="150" cy="100" r="50" fill="#ff0000" />
+        </a>
+    </svg>
+</div>

--- a/xhtml/svg.html
+++ b/xhtml/svg.html
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg contentScriptType="application/ecmascript"
+     contentStyleType="text/css"
+     width="300px" height="200px"
+     xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink" zoomAndPan="magnify">
+    <a href="#human" target="_top" title="#human"
+       xlink:actuate="onRequest" xlink:href="#human"
+       xlink:show="new" xlink:title="#human" xlink:type="simple">
+    <circle cx="150" cy="100" r="50" fill="#ff0000" />
+    </a>
+</svg>


### PR DESCRIPTION
Adds test cases relevant to XHTML processing and xmlns attributes.

Specifically, this tests that xmlns attributes like xlink, which are required for in-SVG crosslinking, are not discarded, as was the previous behaviour. 

```
 <svg svg  ...
         xmlns:svg="http://www.w3.org/2000/svg"
         xmlns:xlink="http://www.w3.org/1999/xlink">
```