### PR TITLE
Test resources and new manifest format for $current-version operation

### DIFF
--- a/r4b/CanonicalVersionTests/Questionnaire.q1-ai.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q1-ai.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q1-ai",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:58.139754+11:00"
+  },
+  "url": "http://example.org/canonical-active-integer",
+  "version": "10.1",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q1-alpha.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q1-alpha.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q1-alpha",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:56.8336794+11:00"
+  },
+  "url": "http://example.org/canonical-alpha",
+  "version": "2.0.1-alpha2",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q1-fhirpath.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q1-fhirpath.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q1-fhirpath",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:59.2681034+11:00"
+  },
+  "url": "http://example.org/canonical-fhirpath",
+  "version": "2.0.1-alpha2",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q1-nat.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q1-nat.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q1-nat",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:59.8206211+11:00"
+  },
+  "url": "http://example.org/canonical-natural",
+  "version": "general1",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q1-semver-pre.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q1-semver-pre.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q1-semver-pre",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:34:01.3648084+11:00"
+  },
+  "url": "http://example.org/canonical-semver-pre-release",
+  "version": "2.0.1-alpha2",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q1-semver.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q1-semver.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q1-semver",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:34:00.8612109+11:00"
+  },
+  "url": "http://example.org/canonical-semver",
+  "version": "2.0.1-alpha2",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q1-si.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q1-si.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q1-si",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:58.7522911+11:00"
+  },
+  "url": "http://example.org/canonical-status-integer",
+  "version": "10.1",
+  "status": "retired"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q2-ai.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q2-ai.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q2-ai",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:58.6832313+11:00"
+  },
+  "url": "http://example.org/canonical-active-integer",
+  "version": "2.2",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q2-alpha.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q2-alpha.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q2-alpha",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:58.0241753+11:00"
+  },
+  "url": "http://example.org/canonical-alpha",
+  "version": "1.0.2",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q2-fhirpath.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q2-fhirpath.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q2-fhirpath",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:59.7587939+11:00"
+  },
+  "url": "http://example.org/canonical-fhirpath",
+  "version": "11.0.2",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q2-nat.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q2-nat.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q2-nat",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:34:00.2870055+11:00"
+  },
+  "url": "http://example.org/canonical-natural",
+  "version": "general2",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q2-semver-pre.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q2-semver-pre.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q2-semver-pre",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:34:01.8528775+11:00"
+  },
+  "url": "http://example.org/canonical-semver-pre-release",
+  "version": "1.0.2",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q2-semver.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q2-semver.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q2-semver",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:34:01.3030101+11:00"
+  },
+  "url": "http://example.org/canonical-semver",
+  "version": "11.0.2",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q2-si.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q2-si.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q2-si",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:59.2048443+11:00"
+  },
+  "url": "http://example.org/canonical-status-integer",
+  "version": "2.2",
+  "status": "draft"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q3-ai.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q3-ai.json
@@ -1,0 +1,20 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q3-ai",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:58.6904944+11:00"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/versionAlgorithm",
+      "valueCoding": {
+        "system": "http://hl7.org/fhir/version-algorithm",
+        "code": "integer"
+      }
+    }
+  ],
+  "url": "http://example.org/canonical-active-integer",
+  "version": "0.3",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q3-alpha.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q3-alpha.json
@@ -1,0 +1,20 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q3-alpha",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:58.0341668+11:00"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/versionAlgorithm",
+      "valueCoding": {
+        "system": "http://hl7.org/fhir/version-algorithm",
+        "code": "alpha"
+      }
+    }
+  ],
+  "url": "http://example.org/canonical-alpha",
+  "version": "12.0.3",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q3-fhirpath.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q3-fhirpath.json
@@ -1,0 +1,17 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q3-fhirpath",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:59.7640877+11:00"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/versionAlgorithm",
+      "valueString": "iif(%version1 > %version2, -1, iif(%version1 < %version2, 1, 0))"
+    }
+  ],
+  "url": "http://example.org/canonical-fhirpath",
+  "version": "1.0.3",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q3-nat.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q3-nat.json
@@ -1,0 +1,20 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q3-nat",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:34:00.2917857+11:00"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/versionAlgorithm",
+      "valueCoding": {
+        "system": "http://hl7.org/fhir/version-algorithm",
+        "code": "natural"
+      }
+    }
+  ],
+  "url": "http://example.org/canonical-natural",
+  "version": "general3",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q3-semver-pre.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q3-semver-pre.json
@@ -1,0 +1,20 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q3-semver-pre",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:34:01.8573145+11:00"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/versionAlgorithm",
+      "valueCoding": {
+        "system": "http://hl7.org/fhir/version-algorithm",
+        "code": "semver"
+      }
+    }
+  ],
+  "url": "http://example.org/canonical-semver-pre-release",
+  "version": "1.0.3",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q3-semver.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q3-semver.json
@@ -1,0 +1,20 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q3-semver",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:34:01.3099313+11:00"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/versionAlgorithm",
+      "valueCoding": {
+        "system": "http://hl7.org/fhir/version-algorithm",
+        "code": "semver"
+      }
+    }
+  ],
+  "url": "http://example.org/canonical-semver",
+  "version": "1.0.3",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q3-si.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q3-si.json
@@ -1,0 +1,20 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q3-si",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:59.2099681+11:00"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/versionAlgorithm",
+      "valueCoding": {
+        "system": "http://hl7.org/fhir/version-algorithm",
+        "code": "integer"
+      }
+    }
+  ],
+  "url": "http://example.org/canonical-status-integer",
+  "version": "0.3",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q4-alpha.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q4-alpha.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q4-alpha",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:58.0659182+11:00"
+  },
+  "url": "http://example.org/canonical-alpha",
+  "version": "2.0.1-alpha1",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q4-fhirpath.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q4-fhirpath.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q4-fhirpath",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:59.7772881+11:00"
+  },
+  "url": "http://example.org/canonical-fhirpath",
+  "version": "2.0.1-alpha1",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q4-nat.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q4-nat.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q4-nat",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:34:00.3080884+11:00"
+  },
+  "url": "http://example.org/canonical-natural",
+  "version": "general1000",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q4-semver-pre.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q4-semver-pre.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q4-semver-pre",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:34:01.8740086+11:00"
+  },
+  "url": "http://example.org/canonical-semver-pre-release",
+  "version": "2.0.1-alpha1",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q4-semver.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q4-semver.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q4-semver",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:34:01.3233223+11:00"
+  },
+  "url": "http://example.org/canonical-semver",
+  "version": "2.0.1-alpha1",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q5-alpha.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q5-alpha.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q5-alpha",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:58.0712997+11:00"
+  },
+  "url": "http://example.org/canonical-alpha",
+  "version": "2.0.1",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q5-fhirpath.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q5-fhirpath.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q5-fhirpath",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:33:59.7854839+11:00"
+  },
+  "url": "http://example.org/canonical-fhirpath",
+  "version": "2.0.1",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q5-nat.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q5-nat.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q5-nat",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:34:00.3127905+11:00"
+  },
+  "url": "http://example.org/canonical-natural",
+  "version": "general200",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q5-semver-pre.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q5-semver-pre.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q5-semver-pre",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:34:01.8776865+11:00"
+  },
+  "url": "http://example.org/canonical-semver-pre-release",
+  "version": "2.0.1",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/Questionnaire.q5-semver.json
+++ b/r4b/CanonicalVersionTests/Questionnaire.q5-semver.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "q5-semver",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-01-03T15:34:01.3298532+11:00"
+  },
+  "url": "http://example.org/canonical-semver",
+  "version": "2.0.1",
+  "status": "active"
+}

--- a/r4b/CanonicalVersionTests/manifest.xml
+++ b/r4b/CanonicalVersionTests/manifest.xml
@@ -1,0 +1,45 @@
+<canonicalversion-tests>
+  <!-- 
+  These tests have been ported from Brian Postlethwaite's C# unit tests
+  https://github.com/brianpos/fhir-net-web-api/blob/feature/r4b/src/Test.WebApi.AspNetCore/CanonicalVersionTests.cs 
+  -->
+  <test name="CurrentCanonicalOperation" url="http://example.org/canonical-active-integer">
+    <rule description="Version expected" expression="resource.version = '10.1'"/>
+    <rule description="Specific resource expected" expression="resource.id = 'q1-ai'"/>
+  </test>
+
+  <test name="CurrentCanonicalOperationByStatus-A" url="http://example.org/canonical-status-integer">
+    <rule description="Version expected" expression="resource.version = '0.3'"/>
+    <rule description="Specific resource expected" expression="resource.id = 'q3-si'"/>
+  </test>
+
+  <test name="CurrentCanonicalOperationByStatus-B" url="http://example.org/canonical-status-integer" status="draft">
+    <rule description="Version expected" expression="resource.version = '2.2'"/>
+    <rule description="Specific resource expected" expression="resource.id = 'q2-si'"/>
+  </test>
+
+  <test name="NumericCanonicalVersions" url="http://example.org/canonical-active-integer">
+    <rule description="Version expected" expression="resource.version = '10.1'"/>
+  </test>
+
+  <test name="SemverCanonicalVersions" url="http://example.org/canonical-semver">
+    <rule description="Version expected" expression="resource.version = '11.0.2'"/>
+  </test>
+
+  <test name="SemverCanonicalVersionsWithPreReleases" url="http://example.org/canonical-semver-pre-release">
+    <rule description="Version expected" expression="resource.version = '2.0.1'"/>
+  </test>
+
+  <test name="FhirpathCanonicalVersions" url="http://example.org/canonical-fhirpath">
+    <rule description="Version expected" expression="resource.version = '2.0.1-alpha2'"/>
+  </test>
+
+  <test name="AlphaCanonicalVersions" url="http://example.org/canonical-alpha">
+    <rule description="Version expected" expression="resource.version = '2.0.1-alpha2'"/>
+  </test>
+
+  <test name="NaturalCanonicalVersions" url="http://example.org/canonical-natural">
+    <rule description="Version expected" expression="resource.version = 'general1000'"/>
+  </test>
+
+</canonicalversion-tests>


### PR DESCRIPTION
As this is a new technique, have included a new format for the manifest file.
It uses all the resources in the folder as the "source data" and will then runs the required code to perform the new $current-version operation.
These samples are for R4B using backport extensions for the versionAlgorithm property.

Example manifest test rule:
``` xml
  <test name="CurrentCanonicalOperationByStatus-B" url="http://example.org/canonical-status-integer" status="draft">
    <rule description="Version expected" expression="resource.version = '2.2'"/>
    <rule description="Specific resource expected" expression="resource.id = 'q2-si'"/>
  </test>
```
The `url` (required) and `status` (optional) properties are provided to the `$current-version` operation and then the resulting resource is tested against the `tests` just as with the other test format - by evaluating the rule expression
