### PR TITLE
Ensure all tests have unique names

### DIFF
--- a/r5/fhirpath/tests-fhir-r5.xml
+++ b/r5/fhirpath/tests-fhir-r5.xml
@@ -219,7 +219,7 @@ Any text enclosed within is ignored
 		</test>
 
 		<!-- testBoolean(patient(), "Patient.name.given.first() = 'Peter'", true); -->
-		<test name="testLiteralString" inputfile="patient-example.xml">
+		<test name="testLiteralString1" inputfile="patient-example.xml">
 			<expression>Patient.name.given.first() = 'Peter'</expression>
 			<output type="boolean">true</output>
 		</test>
@@ -230,7 +230,7 @@ Any text enclosed within is ignored
 		<test name="testLiteralIntegerNegative1Invalid" inputfile="patient-example.xml"><expression invalid="execution">-1.convertsToInteger()</expression></test>
 		<test name="testLiteralIntegerMax" inputfile="patient-example.xml"><expression>2147483647.convertsToInteger()</expression><output type="boolean">true</output></test>
 
-		<test name="testLiteralString" inputfile="patient-example.xml"><expression>'test'.convertsToString()</expression><output type="boolean">true</output></test>
+		<test name="testLiteralString2" inputfile="patient-example.xml"><expression>'test'.convertsToString()</expression><output type="boolean">true</output></test>
 		<test name="testLiteralStringEscapes" inputfile="patient-example.xml"><expression>'\\\/\f\r\n\t\"\`\'\u002a'.convertsToString()</expression><output type="boolean">true</output></test>
 
 		<test name="testLiteralBooleanTrue" inputfile="patient-example.xml"><expression>true.convertsToBoolean()</expression><output type="boolean">true</output></test>
@@ -443,10 +443,10 @@ Any text enclosed within is ignored
 	</group>
 
 	<group name="testExists">
-		<test inputfile="patient-example.xml"><expression>Patient.name.exists()</expression><output type="boolean">true</output></test>
-		<test inputfile="patient-example.xml"><expression>Patient.name.exists(use = 'nickname')</expression><output type="boolean">false</output></test>
-		<test inputfile="patient-example.xml"><expression>Patient.name.exists(use = 'official')</expression><output type="boolean">true</output></test>
-		<test inputfile="patient-example.xml"><expression>Patient.maritalStatus.coding.exists(code = 'P' and system = 'http://terminology.hl7.org/CodeSystem/v3-MaritalStatus')
+		<test name="testExists1" inputfile="patient-example.xml"><expression>Patient.name.exists()</expression><output type="boolean">true</output></test>
+		<test name="testExists2" inputfile="patient-example.xml"><expression>Patient.name.exists(use = 'nickname')</expression><output type="boolean">false</output></test>
+		<test name="testExists3" inputfile="patient-example.xml"><expression>Patient.name.exists(use = 'official')</expression><output type="boolean">true</output></test>
+		<test name="testExists4" inputfile="patient-example.xml"><expression>Patient.maritalStatus.coding.exists(code = 'P' and system = 'http://terminology.hl7.org/CodeSystem/v3-MaritalStatus')
 			or Patient.maritalStatus.coding.exists(code = 'A' and system = 'http://terminology.hl7.org/CodeSystem/v3-MaritalStatus')</expression><output type="boolean">false</output></test>
 	</group>
 
@@ -635,7 +635,7 @@ Any text enclosed within is ignored
 		<test name="testIndexOf3" inputfile="patient-example.xml"><expression>'LogicalModel-Person'.indexOf('')</expression><output type="integer">0</output></test>
 		<test name="testIndexOf5" inputfile="patient-example.xml"><expression>'LogicalModel-Person'.indexOf({}).empty() = true</expression><output type="boolean">true</output></test>
 		<test name="testIndexOf4" inputfile="patient-example.xml"><expression>{}.indexOf('-').empty() = true</expression><output type="boolean">true</output></test>
-		<test name="testIndexOf5" inputfile="patient-example.xml"><expression>{}.indexOf({}).empty() = true</expression><output type="boolean">true</output></test>
+		<test name="testIndexOf6" inputfile="patient-example.xml"><expression>{}.indexOf({}).empty() = true</expression><output type="boolean">true</output></test>
 	</group>
 
 	<group name="testSubstring">
@@ -646,7 +646,7 @@ Any text enclosed within is ignored
 		<test name="testSubstring5" inputfile="patient-example.xml"><expression>'12345'.substring(-1).empty()</expression><output type="boolean">true</output></test>
 		<test name="testSubstring7" inputfile="patient-example.xml"><expression>'LogicalModel-Person'.substring(0, 12)</expression><output type="string">LogicalModel</output></test>
 		<test name="testSubstring8" inputfile="patient-example.xml"><expression>'LogicalModel-Person'.substring(0, 'LogicalModel-Person'.indexOf('-'))</expression><output type="string">LogicalModel</output></test>
-		<test name="testSubstring4" inputfile="patient-example.xml"><expression>{}.substring(25).empty() = true</expression><output type="boolean">true</output></test>
+		<test name="testSubstring9" inputfile="patient-example.xml"><expression>{}.substring(25).empty() = true</expression><output type="boolean">true</output></test>
 	</group>
 
 	<group name="testStartsWith">
@@ -699,13 +699,13 @@ Any text enclosed within is ignored
 		<test name="testMatchesSingleLineMode1"><expression>'A
 			B'.matches('A.*B')</expression><output type="boolean">true</output></test>
 		<test name="testMatchesWithinUrl1"><expression>'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matches('library')</expression><output type="boolean">false</output></test>
-		<test name="testMatchesWithinUrl1"><expression>'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matches('Library')</expression><output type="boolean">true</output></test>
-		<test name="testMatchesWithinUrl1"><expression>'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matches('^Library$')</expression><output type="boolean">false</output></test>
+		<test name="testMatchesWithinUrl2"><expression>'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matches('Library')</expression><output type="boolean">true</output></test>
+		<test name="testMatchesWithinUrl3"><expression>'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matches('^Library$')</expression><output type="boolean">false</output></test>
 		<test name="testMatchesWithinUrl1a"><expression>'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matches('.*Library.*')</expression><output type="boolean">true</output></test>
-		<test name="testMatchesWithinUrl2"><expression>'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matches('Measure')</expression><output type="boolean">false</output></test>
+		<test name="testMatchesWithinUrl4"><expression>'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matches('Measure')</expression><output type="boolean">false</output></test>
 		<test name="testMatchesFullWithinUrl1"><expression>'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matchesFull('library')</expression><output type="boolean">false</output></test>
-		<test name="testMatchesFullWithinUrl1"><expression>'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matchesFull('Library')</expression><output type="boolean">false</output></test>
-		<test name="testMatchesFullWithinUrl1"><expression>'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matchesFull('^Library$')</expression><output type="boolean">false</output></test>
+		<test name="testMatchesFullWithinUrl3"><expression>'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matchesFull('Library')</expression><output type="boolean">false</output></test>
+		<test name="testMatchesFullWithinUrl4"><expression>'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matchesFull('^Library$')</expression><output type="boolean">false</output></test>
 		<test name="testMatchesFullWithinUrl1a"><expression>'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matchesFull('.*Library.*')</expression><output type="boolean">true</output></test>
 		<test name="testMatchesFullWithinUrl2"><expression>'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'.matchesFull('Measure')</expression><output type="boolean">false</output></test>
 <!--		<test name="testMatchesUnicodeCharacters"><expression>'🔥🔥🔥'.matches('🔥+')</expression><output type="boolean">true</output></test> -->
@@ -1300,7 +1300,7 @@ Any text enclosed within is ignored
 		<test name="testTypeA2" inputfile="parameters-example-types.xml"><expression>Parameters.parameter[1].value.is(FHIR.integer)</expression><output type="boolean">true</output></test>
 		<test name="testTypeA3" inputfile="parameters-example-types.xml"><expression>Parameters.parameter[2].value.is(FHIR.uuid)</expression><output type="boolean">true</output></test>
 		<test name="testTypeA4" inputfile="parameters-example-types.xml"><expression>Parameters.parameter[2].value.is(FHIR.uri)</expression><output type="boolean">true</output></test>
-		<test name="testTypeA3" inputfile="parameters-example-types.xml"><expression>Parameters.parameter[3].value.is(FHIR.decimal)</expression><output type="boolean">true</output></test>
+		<test name="testTypeA5" inputfile="parameters-example-types.xml"><expression>Parameters.parameter[3].value.is(FHIR.decimal)</expression><output type="boolean">true</output></test>
 	</group>
 
 	<group name="testConformsTo">
@@ -1401,7 +1401,7 @@ Any text enclosed within is ignored
 		<test name="testFHIRPathAsFunction21" inputfile="patient-example.xml"><expression invalid="execution">Patient.name.as(HumanName).use</expression></test>
 		<test name="testFHIRPathAsFunction22" inputfile="patient-example.xml"><expression>Patient.name.ofType(HumanName).use</expression><output type="code">official</output><output type="code">usual</output><output type="code">maiden</output></test>
 		<test name="testFHIRPathAsFunction23" inputfile="patient-example.xml"><expression invalid="execution">Patient.gender.as(string1)</expression></test>
-		<test name="testFHIRPathAsFunction23" inputfile="patient-example.xml"><expression invalid="execution">Patient.gender.ofType(string1)</expression></test>
+		<test name="testFHIRPathAsFunction24" inputfile="patient-example.xml"><expression invalid="execution">Patient.gender.ofType(string1)</expression></test>
 	</group>
 
 	<group name="miscEngineTests">

--- a/r5/fhirpath/tests-fhir-r5.xml
+++ b/r5/fhirpath/tests-fhir-r5.xml
@@ -1300,7 +1300,7 @@ Any text enclosed within is ignored
 		<test name="testTypeA2" inputfile="parameters-example-types.xml"><expression>Parameters.parameter[1].value.is(FHIR.integer)</expression><output type="boolean">true</output></test>
 		<test name="testTypeA3" inputfile="parameters-example-types.xml"><expression>Parameters.parameter[2].value.is(FHIR.uuid)</expression><output type="boolean">true</output></test>
 		<test name="testTypeA4" inputfile="parameters-example-types.xml"><expression>Parameters.parameter[2].value.is(FHIR.uri)</expression><output type="boolean">true</output></test>
-		<test name="testTypeA5" inputfile="parameters-example-types.xml"><expression>Parameters.parameter[3].value.is(FHIR.decimal)</expression><output type="boolean">true</output></test>
+		<test name="testTypeA" inputfile="parameters-example-types.xml"><expression>Parameters.parameter[3].value.is(FHIR.decimal)</expression><output type="boolean">true</output></test>
 	</group>
 
 	<group name="testConformsTo">


### PR DESCRIPTION
I'm working on implementing elements of FHIR in the Elixir programming language, and noticed that many of the tests in `r5/fhirpath/tests-fhir-r5.xml` have duplicate test names.  This PR fixes that by adding or modifying the "index" suffixed to the names.  Care has been taken to minimize changes (including to formatting, which is why there are multiple commits.)
