### PR TITLE
Fix escape characters in json and use \f instead of Unicode

### DIFF
--- a/tx/simple/simple-expand-regex-response-valueSet.json
+++ b/tx/simple/simple-expand-regex-response-valueSet.json
@@ -14,7 +14,7 @@
       "filter" : [{
         "property" : "code",
         "op" : "regex",
-        "value" : "[^ \t\r\n\u000c]{4}[0-9]"
+        "value" : "[^ \\t\\r\\n\\f]{4}[0-9]"
       }]
     }]
   },


### PR DESCRIPTION
This fixes a test that was failing due to escape characters.