### PR TITLE
Update validate-inactive-2a-response-parameters.json

### DIFF
--- a/tx/inactive/validate-inactive-2a-response-parameters.json
+++ b/tx/inactive/validate-inactive-2a-response-parameters.json
@@ -2,6 +2,11 @@
   "resourceType" : "Parameters",
   "parameter" : [{
     "$optional$" : true,
+    "name" : "code",
+    "valueCode" : "codeInactive"
+  },
+  {
+    "$optional$" : true,
     "name" : "inactive",
     "valueBoolean" : true
   },
@@ -15,7 +20,7 @@
         "details" : {
           "text" : "$external:1:http://hl7.org/fhir/test/ValueSet/inactive-all-active|5.0.0$"
         },
-        "location" : ["Coding"]
+        "location" : ["$choice:Coding|Coding.code$"]
       }]
     }
   },
@@ -26,6 +31,11 @@
   {
     "name" : "result",
     "valueBoolean" : false
+  },
+  {
+    "$optional$" : true,
+    "name" : "system",
+    "valueUri" : "http://hl7.org/fhir/test/CodeSystem/inactive"
   },
   {
     "name" : "version",


### PR DESCRIPTION
Support optional `code` and `system` values and more precise issue location.