### PR TITLE
Added example to test CodeSystem.supplements with versioned canonical

### DIFF
--- a/r5/codesystem-example-supplement-version.xml
+++ b/r5/codesystem-example-supplement-version.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<CodeSystem xmlns="http://hl7.org/fhir">
+  <id value="example-supplement-version"/> 
+  <!-- CodeSystem is not marked as shearable, because supplements should not specify the caseSensive element -->
+  <url value="http://hl7.org/fhir/CodeSystem/example-supplement-version"/> 
+  <version value="1.0.0"/> 
+  <name value="SupplementExample"/> 
+  <title value="Translation for composition-status CodeSystem"/> 
+  <status value="draft"/> 
+  <experimental value="true"/> 
+  <date value="2024-05-07"/> 
+  <publisher value="Acme Co"/> 
+  <contact> 
+    <name value="FHIR project team"/> 
+    <telecom> 
+      <system value="url"/> 
+      <value value="http://hl7.org/fhir"/> 
+    </telecom> 
+  </contact> 
+  <description value="This is an example supplement code system that provides a german translation for the composition-status CodeSystem"/> 
+  <content value="supplement"/>
+  <supplements value="http://hl7.org/fhir/composition-status|5.0.0"/>
+  <concept> 
+    <code value="final"/>
+    <designation> 
+      <language value="de"/>
+      <value value="Abgeschlossen"/> 
+    </designation> 
+  </concept> 
+</CodeSystem> 


### PR DESCRIPTION
This PR adds a test case to test if CodeSystem.supplements works when using a canonical with a version number. This is linked to the issue https://github.com/hapifhir/org.hl7.fhir.core/issues/1611