### PR TITLE
New narrative test case testing versioned display lookup in ConceptMap

### DIFF
--- a/r5/narrative/conceptmap-versioned-canonical-example.html
+++ b/r5/narrative/conceptmap-versioned-canonical-example.html
@@ -1,0 +1,35 @@
+﻿<html><head><link rel="stylesheet" href="http://hl7.org/fhir/fhir.css"/><link rel="stylesheet" href="http://hl7.org/fhir/dist/css/bootstrap.css"/><link rel="stylesheet" href="http://hl7.org/fhir/assets/css/bootstrap-fhir.css"/><link rel="stylesheet" href="http://hl7.org/fhir/assets/css/project.css"/><link rel="stylesheet" href="http://hl7.org/fhir/assets/css/pygments-manni.css"/><link rel="stylesheet" href="http://hl7.org/fhir/jquery-ui.css"/></head><body>
+<div id="segment-content" class="segment"><div class="container"><div class="row"><div class="inner-wrapper"><div class="col-12">
+<p>Narrative</p><div>
+  <p>Mapping from (not specified) to (not specified)</p>
+  <p>DRAFT. Published on 2024-10-05 by HL7 Public Health Working Group . </p>
+  <br/>
+  <p>
+    <b>Group 1 </b>
+Mapping from     <code>http://terminology.hl7.org/CodeSystem/v2-0532</code>
+: expandedYes-NoIndicator (version 2.0.0) to     <code>http://terminology.hl7.org/CodeSystem/v3-NullFlavor</code>
+: NullFlavor (version 3.0.0)
+  </p>
+  <table class="grid">
+    <tr>
+      <td>
+        <b>Source Code</b>
+      </td>
+      <td>
+        <b>Relationship</b>
+      </td>
+      <td>
+        <b>Target Code</b>
+      </td>
+    </tr>
+    <tr>
+      <td>NASK (not asked)</td>
+      <td>
+        <a href="null#equivalent" title="equivalent">is equivalent to</a>
+      </td>
+      <td>NASK (not asked)</td>
+    </tr>
+  </table>
+</div>
+
+</div></div></div></div></div></body></html>

--- a/r5/narrative/conceptmap-versioned-canonical-example.xml
+++ b/r5/narrative/conceptmap-versioned-canonical-example.xml
@@ -1,0 +1,20 @@
+<ConceptMap xmlns="http://hl7.org/fhir">
+  <id value="example-versioned-canonical" />
+  <url value="http://example.org/ConceptMap/example-versioned-canonical" />
+  <version value="0.1" />
+  <title value="Demo map from YesNo to NullFlavors" />
+  <status value="draft" />
+  <date value="2024-10-05" />
+  <publisher value="HL7 Public Health Working Group" />
+  <group>
+    <source value="http://terminology.hl7.org/CodeSystem/v2-0532|2.0.0" />
+    <target value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor|3.0.0" />
+    <element>
+      <code value="NASK" />
+      <target>
+        <code value="NASK" />
+        <relationship value="equivalent" />
+      </target>
+    </element>
+  </group>
+</ConceptMap>

--- a/r5/narrative/manifest.xml
+++ b/r5/narrative/manifest.xml
@@ -35,4 +35,5 @@
   <test gen="true" id="ex-sp" header="true"/>
   <test gen="true" id="ex-st" header="true"/>
   <test gen="true" id="ex-tp" header="true"/>
+  <test gen="true" id="conceptmap-versioned-canonical-example" header="true"/>
 </narrative-tests>


### PR DESCRIPTION
This test case checks if looking up displays for codes, when the ConceptMap does not contain displays, and the canonicals of the source and target CodeSystems are versioned.

This is linked to issues found in https://github.com/hapifhir/org.hl7.fhir.core/issues/1611 . The problems are located in the R4B/R5 DataRenderers, which prevents the lookup of displays from working.