### PR TITLE
Fix incorrect location in outcomes due to cacheing bug

### DIFF
--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -7861,7 +7861,7 @@
                 },
                 "diagnostics": "[192,9]",
                 "expression": [
-                  "Observation.component[0].code.coding[2].system"
+                  "Observation.component[0].code.coding[1].system"
                 ]
               },
               {
@@ -7936,7 +7936,7 @@
               },
               "diagnostics": "[192,9]",
               "expression": [
-                "Observation.component[0].code.coding[2].system"
+                "Observation.component[0].code.coding[1].system"
               ]
             },
             {
@@ -8579,7 +8579,7 @@
               },
               "diagnostics": "[67,8]",
               "expression": [
-                "Observation.code.coding[0].display"
+                "Observation.code.coding[1].display"
               ]
             }
           ]


### PR DESCRIPTION
Two test cases are reporting incorrect locations for code validations. This PR contains the correct locations, and should be merged to allow https://github.com/hapifhir/org.hl7.fhir.core/pull/1700 to pass tests.