### PR TITLE
Fix code validations with no locale

### DIFF
--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -1618,7 +1618,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Barbiturates and derivatives' for http://www.whocc.no/atc#N02AA. Valid display is 'Natural opium alkaloids' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Barbiturates and derivatives' for http://www.whocc.no/atc#N02AA. Valid display is 'Natural opium alkaloids' (for the language(s) 'en-US')"
               },
               "diagnostics": "[27,10]",
               "expression": [
@@ -8277,7 +8277,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Cholesterol [Moles/​volume] in Serum or Plasma' for http://loinc.org#35200-5. Valid display is one of 50 choices: 'Cholesterol [Mass or Moles/volume] in Serum or Plasma', 'Cholest SerPl-msCnc' (en-US), '化学' (zh-CN), '化学检验项目' (zh-CN), '化学检验项目类' (zh-CN), '化学类' (zh-CN), '化学试验' (zh-CN), '非刺激耐受型化学检验项目' (zh-CN), '非刺激耐受型化学检验项目类' (zh-CN), '非刺激耐受型化学试验' (zh-CN), '非刺激耐受型化学试验类 可用数量表示的' (zh-CN), '定量性' (zh-CN), '数值型' (zh-CN), '数量型' (zh-CN), '连续数值型标尺 总胆固醇' (zh-CN), '胆固醇总计' (zh-CN), '胆甾醇' (zh-CN), '脂类' (zh-CN), '脂质 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 血清或血浆 质量或摩尔浓度' (zh-CN), '质量或摩尔浓度(单位体积)' (zh-CN), '质量或物质的量浓度(单位体积)' (zh-CN), 'Juhuslik Kvantitatiivne Plasma Seerum Seerum või plasma' (et-EE), 'Cholest' (pt-BR), 'Chol' (pt-BR), 'Choles' (pt-BR), 'Lipid' (pt-BR), 'Cholesterol total' (pt-BR), 'Cholesterols' (pt-BR), 'Level' (pt-BR), 'Point in time' (pt-BR), 'Random' (pt-BR), 'SerPl' (pt-BR), 'SerPlas' (pt-BR), 'SerP' (pt-BR), 'Serum' (pt-BR), 'SR' (pt-BR), 'Plasma' (pt-BR), 'Pl' (pt-BR), 'Plsm' (pt-BR), 'Quantitative' (pt-BR), 'QNT' (pt-BR), 'Quant' (pt-BR), 'Quan' (pt-BR), 'Chemistry' (pt-BR), 'Chimica Concentrazione Sostanza o Massa Plasma Punto nel tempo (episodio) Siero Siero o Plasma' (it-IT), 'Количественный Массовая или Молярная Концентрация Плазма Сыворотка Сыворотка или Плазма Точка во времени' (ru-RU) or 'Момент Холестерин' (ru-RU) (for the language(s) '--')"
+                "text": "Wrong Display Name 'Cholesterol [Moles/\u200Bvolume] in Serum or Plasma' for http://loinc.org#35200-5. Valid display is 'Cholesterol [Mass or Moles/volume] in Serum or Plasma' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[66,8]",
               "expression": [
@@ -8305,7 +8305,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Cholesterol [Moles/​volume] in Serum or Plasma' for http://loinc.org#35200-5. Valid display is one of 50 choices: 'Cholesterol [Mass or Moles/volume] in Serum or Plasma', 'Cholest SerPl-msCnc' (en-US), '化学' (zh-CN), '化学检验项目' (zh-CN), '化学检验项目类' (zh-CN), '化学类' (zh-CN), '化学试验' (zh-CN), '非刺激耐受型化学检验项目' (zh-CN), '非刺激耐受型化学检验项目类' (zh-CN), '非刺激耐受型化学试验' (zh-CN), '非刺激耐受型化学试验类 可用数量表示的' (zh-CN), '定量性' (zh-CN), '数值型' (zh-CN), '数量型' (zh-CN), '连续数值型标尺 总胆固醇' (zh-CN), '胆固醇总计' (zh-CN), '胆甾醇' (zh-CN), '脂类' (zh-CN), '脂质 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 血清或血浆 质量或摩尔浓度' (zh-CN), '质量或摩尔浓度(单位体积)' (zh-CN), '质量或物质的量浓度(单位体积)' (zh-CN), 'Juhuslik Kvantitatiivne Plasma Seerum Seerum või plasma' (et-EE), 'Cholest' (pt-BR), 'Chol' (pt-BR), 'Choles' (pt-BR), 'Lipid' (pt-BR), 'Cholesterol total' (pt-BR), 'Cholesterols' (pt-BR), 'Level' (pt-BR), 'Point in time' (pt-BR), 'Random' (pt-BR), 'SerPl' (pt-BR), 'SerPlas' (pt-BR), 'SerP' (pt-BR), 'Serum' (pt-BR), 'SR' (pt-BR), 'Plasma' (pt-BR), 'Pl' (pt-BR), 'Plsm' (pt-BR), 'Quantitative' (pt-BR), 'QNT' (pt-BR), 'Quant' (pt-BR), 'Quan' (pt-BR), 'Chemistry' (pt-BR), 'Chimica Concentrazione Sostanza o Massa Plasma Punto nel tempo (episodio) Siero Siero o Plasma' (it-IT), 'Количественный Массовая или Молярная Концентрация Плазма Сыворотка Сыворотка или Плазма Точка во времени' (ru-RU) or 'Момент Холестерин' (ru-RU) (for the language(s) '--')"
+                "text": "Wrong Display Name 'Cholesterol [Moles/\u200Bvolume] in Serum or Plasma' for http://loinc.org#35200-5. Valid display is 'Cholesterol [Mass or Moles/volume] in Serum or Plasma' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[66,8]",
               "expression": [
@@ -8355,7 +8355,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Cholesterol [Moles/​volume] in Serum or Plasma' for http://loinc.org#35200-5. Valid display is one of 50 choices: 'Cholesterol [Mass or Moles/volume] in Serum or Plasma', 'Cholest SerPl-msCnc' (en-US), '化学' (zh-CN), '化学检验项目' (zh-CN), '化学检验项目类' (zh-CN), '化学类' (zh-CN), '化学试验' (zh-CN), '非刺激耐受型化学检验项目' (zh-CN), '非刺激耐受型化学检验项目类' (zh-CN), '非刺激耐受型化学试验' (zh-CN), '非刺激耐受型化学试验类 可用数量表示的' (zh-CN), '定量性' (zh-CN), '数值型' (zh-CN), '数量型' (zh-CN), '连续数值型标尺 总胆固醇' (zh-CN), '胆固醇总计' (zh-CN), '胆甾醇' (zh-CN), '脂类' (zh-CN), '脂质 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 血清或血浆 质量或摩尔浓度' (zh-CN), '质量或摩尔浓度(单位体积)' (zh-CN), '质量或物质的量浓度(单位体积)' (zh-CN), 'Juhuslik Kvantitatiivne Plasma Seerum Seerum või plasma' (et-EE), 'Cholest' (pt-BR), 'Chol' (pt-BR), 'Choles' (pt-BR), 'Lipid' (pt-BR), 'Cholesterol total' (pt-BR), 'Cholesterols' (pt-BR), 'Level' (pt-BR), 'Point in time' (pt-BR), 'Random' (pt-BR), 'SerPl' (pt-BR), 'SerPlas' (pt-BR), 'SerP' (pt-BR), 'Serum' (pt-BR), 'SR' (pt-BR), 'Plasma' (pt-BR), 'Pl' (pt-BR), 'Plsm' (pt-BR), 'Quantitative' (pt-BR), 'QNT' (pt-BR), 'Quant' (pt-BR), 'Quan' (pt-BR), 'Chemistry' (pt-BR), 'Chimica Concentrazione Sostanza o Massa Plasma Punto nel tempo (episodio) Siero Siero o Plasma' (it-IT), 'Количественный Массовая или Молярная Концентрация Плазма Сыворотка Сыворотка или Плазма Точка во времени' (ru-RU) or 'Момент Холестерин' (ru-RU) (for the language(s) '--')"
+                "text": "Wrong Display Name 'Cholesterol [Moles/\u200Bvolume] in Serum or Plasma' for http://loinc.org#35200-5. Valid display is 'Cholesterol [Mass or Moles/volume] in Serum or Plasma' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[67,8]",
               "expression": [
@@ -8547,7 +8547,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Triglyceride [Moles/​volume] in Serum or Plasma' for http://loinc.org#35217-9. Valid display is one of 50 choices: 'Triglyceride [Mass or Moles/volume] in Serum or Plasma', 'Trigl SerPl-msCnc' (en-US), 'TG' (zh-CN), 'Trigly' (zh-CN), '甘油三脂' (zh-CN), '甘油三酸酯' (zh-CN), '三酸甘油酯' (zh-CN), '甘油三酸脂' (zh-CN), '三酸甘油脂 化学' (zh-CN), '化学检验项目' (zh-CN), '化学检验项目类' (zh-CN), '化学类' (zh-CN), '化学试验' (zh-CN), '非刺激耐受型化学检验项目' (zh-CN), '非刺激耐受型化学检验项目类' (zh-CN), '非刺激耐受型化学试验' (zh-CN), '非刺激耐受型化学试验类 可用数量表示的' (zh-CN), '定量性' (zh-CN), '数值型' (zh-CN), '数量型' (zh-CN), '连续数值型标尺 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 血清或血浆 质量或摩尔浓度' (zh-CN), '质量或摩尔浓度(单位体积)' (zh-CN), '质量或物质的量浓度(单位体积)' (zh-CN), 'Juhuslik Kvantitatiivne Plasma Seerum Seerum või plasma' (et-EE), 'Trigl' (pt-BR), 'Triglycrides' (pt-BR), 'Trig' (pt-BR), 'Triglycerides' (pt-BR), 'Level' (pt-BR), 'Point in time' (pt-BR), 'Random' (pt-BR), 'SerPl' (pt-BR), 'SerPlas' (pt-BR), 'SerP' (pt-BR), 'Serum' (pt-BR), 'SR' (pt-BR), 'Plasma' (pt-BR), 'Pl' (pt-BR), 'Plsm' (pt-BR), 'Quantitative' (pt-BR), 'QNT' (pt-BR), 'Quant' (pt-BR), 'Quan' (pt-BR), 'Chemistry' (pt-BR), 'Chimica Concentrazione Sostanza o Massa Plasma Punto nel tempo (episodio) Siero Siero o Plasma' (it-IT), 'Количественный Массовая или Молярная Концентрация Плазма Сыворотка Сыворотка или Плазма Точка во времени' (ru-RU) or 'Момент' (ru-RU) (for the language(s) '--')"
+                "text": "Wrong Display Name 'Triglyceride [Moles/\u200Bvolume] in Serum or Plasma' for http://loinc.org#35217-9. Valid display is 'Triglyceride [Mass or Moles/volume] in Serum or Plasma' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[67,8]",
               "expression": [
@@ -8575,7 +8575,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Triglyceride [Moles/​volume] in Serum or Plasma' for http://loinc.org#35217-9. Valid display is one of 50 choices: 'Triglyceride [Mass or Moles/volume] in Serum or Plasma', 'Trigl SerPl-msCnc' (en-US), 'TG' (zh-CN), 'Trigly' (zh-CN), '甘油三脂' (zh-CN), '甘油三酸酯' (zh-CN), '三酸甘油酯' (zh-CN), '甘油三酸脂' (zh-CN), '三酸甘油脂 化学' (zh-CN), '化学检验项目' (zh-CN), '化学检验项目类' (zh-CN), '化学类' (zh-CN), '化学试验' (zh-CN), '非刺激耐受型化学检验项目' (zh-CN), '非刺激耐受型化学检验项目类' (zh-CN), '非刺激耐受型化学试验' (zh-CN), '非刺激耐受型化学试验类 可用数量表示的' (zh-CN), '定量性' (zh-CN), '数值型' (zh-CN), '数量型' (zh-CN), '连续数值型标尺 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 血清或血浆 质量或摩尔浓度' (zh-CN), '质量或摩尔浓度(单位体积)' (zh-CN), '质量或物质的量浓度(单位体积)' (zh-CN), 'Juhuslik Kvantitatiivne Plasma Seerum Seerum või plasma' (et-EE), 'Trigl' (pt-BR), 'Triglycrides' (pt-BR), 'Trig' (pt-BR), 'Triglycerides' (pt-BR), 'Level' (pt-BR), 'Point in time' (pt-BR), 'Random' (pt-BR), 'SerPl' (pt-BR), 'SerPlas' (pt-BR), 'SerP' (pt-BR), 'Serum' (pt-BR), 'SR' (pt-BR), 'Plasma' (pt-BR), 'Pl' (pt-BR), 'Plsm' (pt-BR), 'Quantitative' (pt-BR), 'QNT' (pt-BR), 'Quant' (pt-BR), 'Quan' (pt-BR), 'Chemistry' (pt-BR), 'Chimica Concentrazione Sostanza o Massa Plasma Punto nel tempo (episodio) Siero Siero o Plasma' (it-IT), 'Количественный Массовая или Молярная Концентрация Плазма Сыворотка Сыворотка или Плазма Точка во времени' (ru-RU) or 'Момент' (ru-RU) (for the language(s) '--')"
+                "text": "Wrong Display Name 'Triglyceride [Moles/\u200Bvolume] in Serum or Plasma' for http://loinc.org#35217-9. Valid display is 'Triglyceride [Mass or Moles/volume] in Serum or Plasma' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[67,8]",
               "expression": [
@@ -10210,7 +10210,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Allergies and adverse reactions' for http://loinc.org#48765-2. Valid display is one of 28 choices: 'Allergies and adverse reactions Document', 'Allergies &or adverse reactions Doc' (en-US), '临床文档型' (zh-CN), '临床文档' (zh-CN), '文档' (zh-CN), '文书' (zh-CN), '医疗文书' (zh-CN), '临床医疗文书 医疗服务对象' (zh-CN), '客户' (zh-CN), '病人' (zh-CN), '病患' (zh-CN), '病号' (zh-CN), '超系统 - 病人 发现是一个原子型临床观察指标，并不是作为印象的概括陈述。体格检查、病史、系统检查及其他此类观察指标的属性均为发现。它们的标尺对于编码型发现可能是名义型，而对于叙述型文本之中所报告的发现，则可能是叙述型。' (zh-CN), '发现物' (zh-CN), '所见' (zh-CN), '结果' (zh-CN), '结论 变态反应与不良反应 文档.其他' (zh-CN), '杂项类文档' (zh-CN), '其他文档 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 杂项' (zh-CN), '杂项类' (zh-CN), '杂项试验 过敏反应' (zh-CN), '过敏' (zh-CN), 'Allergie e reazioni avverse Documentazione miscellanea Miscellanea Osservazione paziente Punto nel tempo (episodio)' (it-IT), 'Документ Точка во времени' (ru-RU) or 'Момент' (ru-RU) (for the language(s) '--')"
+                "text": "Allergies and adverse reactions' for http://loinc.org#48765-2. Valid display is 'Allergies and adverse reactions Document' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[26,11]",
               "expression": [
@@ -10319,7 +10319,7 @@
                 "severity": "error",
                 "code": "invalid",
                 "details": {
-                  "text": "Wrong Display Name 'Allergies and adverse reactions' for http://loinc.org#48765-2. Valid display is one of 28 choices: 'Allergies and adverse reactions Document', 'Allergies &or adverse reactions Doc' (en-US), '临床文档型' (zh-CN), '临床文档' (zh-CN), '文档' (zh-CN), '文书' (zh-CN), '医疗文书' (zh-CN), '临床医疗文书 医疗服务对象' (zh-CN), '客户' (zh-CN), '病人' (zh-CN), '病患' (zh-CN), '病号' (zh-CN), '超系统 - 病人 发现是一个原子型临床观察指标，并不是作为印象的概括陈述。体格检查、病史、系统检查及其他此类观察指标的属性均为发现。它们的标尺对于编码型发现可能是名义型，而对于叙述型文本之中所报告的发现，则可能是叙述型。' (zh-CN), '发现物' (zh-CN), '所见' (zh-CN), '结果' (zh-CN), '结论 变态反应与不良反应 文档.其他' (zh-CN), '杂项类文档' (zh-CN), '其他文档 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 杂项' (zh-CN), '杂项类' (zh-CN), '杂项试验 过敏反应' (zh-CN), '过敏' (zh-CN), 'Allergie e reazioni avverse Documentazione miscellanea Miscellanea Osservazione paziente Punto nel tempo (episodio)' (it-IT), 'Документ Точка во времени' (ru-RU) or 'Момент' (ru-RU) (for the language(s) '--')"
+                  "text": "Wrong Display Name 'Allergies and adverse reactions' for http://loinc.org#48765-2. Valid display is 'Allergies and adverse reactions Document' (en-US) (for the language(s) 'en-US')"
                 },
                 "diagnostics": "[26,11]",
                 "expression": [
@@ -33282,7 +33282,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Paracetamol 500mg tablets' for http://snomed.info/sct#322236009. Valid display is one of 3 choices: 'Acetaminophen 500 mg oral tablet', 'Paracetamol 500 mg oral tablet' or 'Product containing precisely paracetamol 500 milligram/1 each conventional release oral tablet (clinical drug)' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Paracetamol 500mg tablets' for http://snomed.info/sct#322236009. Valid display is one of 3 choices: 'Acetaminophen 500 mg oral tablet', 'Paracetamol 500 mg oral tablet' or 'Product containing precisely paracetamol 500 milligram/1 each conventional release oral tablet (clinical drug)' (for the language(s) 'en-US')"
               },
               "diagnostics": "[223,10]",
               "expression": [
@@ -33404,7 +33404,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Ibuprofen 200mg tablets' for http://snomed.info/sct#329652003. Valid display is one of 2 choices: 'Ibuprofen 200 mg oral tablet' or 'Product containing precisely ibuprofen 200 milligram/1 each conventional release oral tablet (clinical drug)' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Ibuprofen 200mg tablets' for http://snomed.info/sct#329652003. Valid display is one of 2 choices: 'Ibuprofen 200 mg oral tablet' or 'Product containing precisely ibuprofen 200 milligram/1 each conventional release oral tablet (clinical drug)' (for the language(s) 'en-US')"
               },
               "diagnostics": "[435,10]",
               "expression": [

--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -12562,7 +12562,7 @@
                 "severity": "error",
                 "code": "invalid",
                 "details": {
-                  "text": "Wrong Display Name 'Progress note' for http://snomed.info/sct#371532007. Valid display is one of 3 choices: 'Progress report', 'Report of subsequent visit' or 'Progress report (record artifact)' (for the language(s) '--')"
+                  "text": "Wrong Display Name 'Progress note' for http://snomed.info/sct#371532007. Valid display is one of 3 choices: 'Progress report', 'Report of subsequent visit' or 'Progress report (record artifact)' (for the language(s) 'en-US')"
                 },
                 "diagnostics": "[5,11]",
                 "expression": [
@@ -12636,7 +12636,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Progress note' for http://snomed.info/sct#371532007. Valid display is one of 3 choices: 'Progress report', 'Report of subsequent visit' or 'Progress report (record artifact)' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Progress note' for http://snomed.info/sct#371532007. Valid display is one of 3 choices: 'Progress report', 'Report of subsequent visit' or 'Progress report (record artifact)' (for the language(s) 'en-US')"
               },
               "diagnostics": "[5,11]",
               "expression": [
@@ -22530,7 +22530,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Traveller's Diarrhea (disorder)' for http://snomed.info/sct#11840006. Valid display is one of 4 choices: 'Traveler's diarrhea', 'Turista', 'Traveler's diarrhoea' or 'Traveler's diarrhea (disorder)' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Traveller's Diarrhea (disorder)' for http://snomed.info/sct#11840006. Valid display is one of 4 choices: 'Traveler's diarrhea', 'Turista', 'Traveler's diarrhoea' or 'Traveler's diarrhea (disorder)' (for the language(s) 'en-US')"
               },
               "diagnostics": "[158,29]",
               "expression": [
@@ -22753,7 +22753,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Traveller's Diarrhea (disorder)' for http://snomed.info/sct#11840006. Valid display is one of 4 choices: 'Traveler's diarrhea', 'Turista', 'Traveler's diarrhoea' or 'Traveler's diarrhea (disorder)' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Traveller's Diarrhea (disorder)' for http://snomed.info/sct#11840006. Valid display is one of 4 choices: 'Traveler's diarrhea', 'Turista', 'Traveler's diarrhoea' or 'Traveler's diarrhea (disorder)' (for the language(s) 'en-US')"
               },
               "diagnostics": "[162,29]",
               "expression": [
@@ -27276,7 +27276,7 @@
               "severity": "warning",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Moderate' for http://snomed.info/sct#6736007. Valid display is one of 4 choices: 'Midgrade', 'Moderate (severity modifier) (qualifier value)', 'Moderate (severity modifier)' or 'Moderate severity' (for the language(s) 'en')"
+                "text": "Wrong Display Name 'Moderate' for http://snomed.info/sct#6736007. Valid display is one of 4 choices: 'Midgrade', 'Moderate (severity modifier) (qualifier value)', 'Moderate (severity modifier)' or 'Moderate severity' (for the language(s) 'en-US')"
               },
               "diagnostics": "[1366,10]",
               "expression": [
@@ -27321,7 +27321,7 @@
               "severity": "warning",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Moderate' for http://snomed.info/sct#6736007. Valid display is one of 4 choices: 'Midgrade', 'Moderate (severity modifier) (qualifier value)', 'Moderate (severity modifier)' or 'Moderate severity' (for the language(s) 'en')"
+                "text": "Wrong Display Name 'Moderate' for http://snomed.info/sct#6736007. Valid display is one of 4 choices: 'Midgrade', 'Moderate (severity modifier) (qualifier value)', 'Moderate (severity modifier)' or 'Moderate severity' (for the language(s) 'en-US')"
               },
               "diagnostics": "[1366,10]",
               "expression": [
@@ -32788,7 +32788,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'NDC labeler code request' for http://loinc.org#51726-8. Valid display is one of 22 choices: 'FDA product label NDC labeler code request', 'FDA label NDC labeler code request' (en-US), 'FDA 药品标签 National Drug Code' (zh-CN), 'NDC' (zh-CN), '国家药品验证号' (zh-CN), '国家药品代码' (zh-CN), '美国国家药品代码' (zh-CN), '全国药品代码' (zh-CN), 'NDC labeler code' (zh-CN), 'NDC 标识者识别代码' (zh-CN), 'NDC 厂家号' (zh-CN), 'NDC 贴签厂商代码请求' (zh-CN), 'NDC 标签号申请 叙述' (zh-CN), '叙述性文字' (zh-CN), '报告' (zh-CN), '报告型' (zh-CN), '文字叙述' (zh-CN), '文本叙述型' (zh-CN), '文本描述' (zh-CN), '文本描述型 监管类文档' (zh-CN), 'Documentazione normativa Etichetta di prodotto della Food and Drug Administ' (it-IT) or 'Описательный' (ru-RU) (for the language(s) '--')"
+                "text": "Wrong Display Name 'NDC labeler code request' for http://loinc.org#51726-8. Valid display is 'FDA product label NDC labeler code request' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[16,10]",
               "expression": [
@@ -32805,7 +32805,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Foreign Facility's United States Agent' for http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C73330. Valid display is 'UNITED STATES AGENT' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Foreign Facility's United States Agent' for http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C73330. Valid display is 'UNITED STATES AGENT' (for the language(s) 'en-US')"
               },
               "diagnostics": "[51,16]",
               "expression": [
@@ -39702,7 +39702,7 @@
                 "severity": "error",
                 "code": "invalid",
                 "details": {
-                  "text": "Wrong Display Name 'O2 % BldC Oximetry' for http://loinc.org#59408-5. Valid display is one of 26 choices: 'Oxygen saturation in Arterial blood by Pulse oximetry', 'SaO2 % BldA PulseOx' (en-US), 'O2 SaO2' (pl-PL), 'saturacja krwi tlenem' (pl-PL), 'MFr O2' (zh-CN), 'tO2' (zh-CN), '总氧' (zh-CN), '氧气 SaO2 动脉血 动脉血O2饱和度 可用数量表示的' (zh-CN), '定量性' (zh-CN), '数值型' (zh-CN), '数量型' (zh-CN), '连续数值型标尺 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 肺部测量指标与呼吸机管理 脉搏血氧测定法' (zh-CN), '脉搏血氧定量' (zh-CN), '脉搏血氧测定' (zh-CN), '脉搏血氧仪 血氧测定法 饱和 饱和状态 饱和程度' (zh-CN), 'O2-Sättigung' (de-DE), 'Frazione di massa Gestione ventilazione polmonare Punto nel tempo (episodio) Sangue arterioso' (it-IT), 'Oksijen doymuşluğu' (tr-TR), 'Количественный Кровь артериальная Массовая доля Насыщение кислородом Оксигемометрия' (ru-RU), 'Гемоксиметрия Точка во времени' (ru-RU), 'Момент' (ru-RU), 'zuurstofsaturatiemeting' (nl-NL) or 'O2 SatO2' (fr-BE) (for the language(s) '--')"
+                  "text": "Wrong Display Name 'O2 % BldC Oximetry' for http://loinc.org#59408-5. Valid display is 'Oxygen saturation in Arterial blood by Pulse oximetry' (en-US) (for the language(s) 'en-US')"
                 },
                 "diagnostics": "[44,10]",
                 "expression": [
@@ -39741,7 +39741,7 @@
                 "severity": "error",
                 "code": "invalid",
                 "details": {
-                  "text": "Wrong Display Name 'Flow Rate' for http://loinc.org#3151-8. Valid display is one of 37 choices: 'Inhaled oxygen flow rate', 'Inhaled O2 flow rate' (en-US), 'O2' (zh-CN), 'tO2' (zh-CN), '总氧' (zh-CN), '氧气 体积速率(单位时间)' (zh-CN), '单位时间内体积的变化速率' (zh-CN), '流量 可用数量表示的' (zh-CN), '定量性' (zh-CN), '数值型' (zh-CN), '数量型' (zh-CN), '连续数值型标尺 吸入气' (zh-CN), '吸入气体' (zh-CN), '吸入的空气 所吸入的氧' (zh-CN), '已吸入的氧气 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 气 气体类 空气' (zh-CN), 'Inhaled O2' (pt-BR), 'vRate' (pt-BR), 'Volume rate' (pt-BR), 'Flow' (pt-BR), 'Point in time' (pt-BR), 'Random' (pt-BR), 'IhG' (pt-BR), 'Inhaled Gas' (pt-BR), 'Inspired' (pt-BR), 'Quantitative' (pt-BR), 'QNT' (pt-BR), 'Quant' (pt-BR), 'Quan' (pt-BR), 'Gases' (pt-BR), 'Clinico Gas inalati Punto nel tempo (episodio) Tasso di Volume' (it-IT), 'Количественный Объемная скорость Точка во времени' (ru-RU), 'Момент' (ru-RU), 'ingeademde O2' (nl-NL) or 'O2-Zufuhr' (de-AT) (for the language(s) '--')"
+                  "text": "Wrong Display Name 'Flow Rate' for http://loinc.org#3151-8. Valid display is 'Inhaled oxygen flow rate' (en-US) (for the language(s) 'en-US')"
                 },
                 "diagnostics": "[106,14]",
                 "expression": [

--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -1728,7 +1728,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Allergies' for http://loinc.org#48765-2. Valid display is one of 28 choices: 'Allergies and adverse reactions Document', 'Allergies &or adverse reactions Doc' (en-US), '临床文档型' (zh-CN), '临床文档' (zh-CN), '文档' (zh-CN), '文书' (zh-CN), '医疗文书' (zh-CN), '临床医疗文书 医疗服务对象' (zh-CN), '客户' (zh-CN), '病人' (zh-CN), '病患' (zh-CN), '病号' (zh-CN), '超系统 - 病人 发现是一个原子型临床观察指标，并不是作为印象的概括陈述。体格检查、病史、系统检查及其他此类观察指标的属性均为发现。它们的标尺对于编码型发现可能是名义型，而对于叙述型文本之中所报告的发现，则可能是叙述型。' (zh-CN), '发现物' (zh-CN), '所见' (zh-CN), '结果' (zh-CN), '结论 变态反应与不良反应 文档.其他' (zh-CN), '杂项类文档' (zh-CN), '其他文档 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 杂项' (zh-CN), '杂项类' (zh-CN), '杂项试验 过敏反应' (zh-CN), '过敏' (zh-CN), 'Allergie e reazioni avverse Documentazione miscellanea Miscellanea Osservazione paziente Punto nel tempo (episodio)' (it-IT), 'Документ Точка во времени' (ru-RU) or 'Момент' (ru-RU) (for the language(s) '--')"
+                "text": "Wrong Display Name 'Allergies' for http://loinc.org#48765-2. Valid display is 'Allergies and adverse reactions Document' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[75,20]",
               "expression": [
@@ -1745,7 +1745,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Plan of care' for http://loinc.org#18776-5. Valid display is one of 30 choices: 'Plan of care note', 'Plan of care note' (en-US), '临床文档型' (zh-CN), '临床文档' (zh-CN), '文档' (zh-CN), '文书' (zh-CN), '医疗文书' (zh-CN), '临床医疗文书 事件发生的地方' (zh-CN), '场景' (zh-CN), '环境' (zh-CN), '背景 医疗服务（照护服务、护理服务、护理、照护、医疗照护、诊疗、诊疗服务、照顾、看护）计划（方案）记录 发现是一个原子型临床观察指标，并不是作为印象的概括陈述。体格检查、病史、系统检查及其他此类观察指标的属性均为发现。它们的标尺对于编码型发现可能是名义型，而对于叙述型文本之中所报告的发现，则可能是叙述型。' (zh-CN), '发现物' (zh-CN), '所见' (zh-CN), '结果' (zh-CN), '结论 文档本体' (zh-CN), '临床文档本体' (zh-CN), '文档本体' (zh-CN), '文书本体' (zh-CN), '医疗文书本体' (zh-CN), '临床医疗文书本体 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 未加明确说明的角色 笔记' (zh-CN), '按语' (zh-CN), '注释' (zh-CN), '说明' (zh-CN), '票据' (zh-CN), '单据' (zh-CN), '证明书' (zh-CN) or 'Documentazione dell'ontologia Osservazione Piano di cura Punto nel tempo (episodio) Ruolo non specificato' (it-IT) (for the language(s) '--')"
+                "text": "Wrong Display Name 'Plan of care' for http://loinc.org#18776-5. Valid display is 'Plan of care note' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[220,20]",
               "expression": [
@@ -1917,7 +1917,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Review of systems Narrative Reporte' for http://loinc.org#10187-3. Valid display is one of 41 choices: 'Review of systems Narrative - Reported', 'Review of systems' (en-US), '医疗服务对象' (zh-CN), '客户' (zh-CN), '病人' (zh-CN), '病患' (zh-CN), '病号' (zh-CN), '超系统 - 病人 历史纪录与体格检查 历史纪录与体格检查.历史记录' (zh-CN), '历史纪录与体格检查.历史记录类' (zh-CN), '历史纪录与体格检查.历史记录类别' (zh-CN), '历史纪录与体格检查.病史' (zh-CN), '历史纪录与体格检查.病史类' (zh-CN), '历史纪录与体格检查.病史类别' (zh-CN), '历史纪录与体格检查.病史记录' (zh-CN), '历史纪录与体格检查.病史记录类' (zh-CN), '历史纪录与体格检查.病史记录类别' (zh-CN), '历史纪录与体格检查小节.历史记录' (zh-CN), '历史纪录与体格检查小节.历史记录类' (zh-CN), '历史纪录与体格检查小节.历史记录类别' (zh-CN), '历史纪录与体格检查小节.病史' (zh-CN), '历史纪录与体格检查小节.病史类' (zh-CN), '历史纪录与体格检查小节.病史类别 历史纪录与体格检查小节 发现是一个原子型临床观察指标，并不是作为印象的概括陈述。体格检查、病史、系统检查及其他此类观察指标的属性均为发现。它们的标尺对于编码型发现可能是名义型，而对于叙述型文本之中所报告的发现，则可能是叙述型。' (zh-CN), '发现物' (zh-CN), '所见' (zh-CN), '结果' (zh-CN), '结论 叙述' (zh-CN), '叙述性文字' (zh-CN), '报告' (zh-CN), '报告型' (zh-CN), '文字叙述' (zh-CN), '文本叙述型' (zh-CN), '文本描述' (zh-CN), '文本描述型 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 病史与体格检查 系统回顾' (zh-CN), '系统审核' (zh-CN), 'Anamnesi Osservazione paziente Punto nel tempo (episodio)' (it-IT), 'Анамнестические сведения' (ru-RU), 'Сообщенная третьим лицом информация Описательный Точка во времени' (ru-RU) or 'Момент' (ru-RU) (for the language(s) '--')"
+                "text": "Wrong Display Name 'Review of systems Narrative Reporte' for http://loinc.org#10187-3. Valid display is 'Review of systems Narrative - Reported' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[545,20]",
               "expression": [
@@ -1934,7 +1934,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Administrative information' for http://loinc.org#87504-7. Valid display is 'LCDS v4.00 - Administrative information - discharge [CMS Assessment]' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Administrative information' for http://loinc.org#87504-7. Valid display is 'LCDS v4.00 - Administrative information - discharge during assessment period [CMS Assessment]' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[565,20]",
               "expression": [
@@ -3196,7 +3196,7 @@
                 "severity": "error",
                 "code": "invalid",
                 "details": {
-                  "text": "Wrong Display Name 'Cother' for http://hl7.org/fhir/v3/RoleCode#MTH. Valid display is 'mother' (for the language(s) '--')"
+                  "text": "Wrong Display Name 'Cother' for http://hl7.org/fhir/v3/RoleCode#MTH. Valid display is 'mother' (for the language(s) 'en-US')"
                 },
                 "diagnostics": "[8,10]",
                 "expression": [
@@ -3226,7 +3226,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Cother' for http://hl7.org/fhir/v3/RoleCode#MTH. Valid display is 'mother' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Cother' for http://hl7.org/fhir/v3/RoleCode#MTH. Valid display is 'mother' (for the language(s) 'en-US')"
               },
               "diagnostics": "[8,10]",
               "expression": [
@@ -3294,7 +3294,7 @@
                 "severity": "error",
                 "code": "invalid",
                 "details": {
-                  "text": "Wrong Display Name 'Laboratory test finding (finding)' for http://snomed.info/sct#118246004. Valid display is one of 4 choices: 'Laboratory test finding', 'Laboratory test observations', 'Laboratory test result' or 'Laboratory test finding (navigational concept)' (for the language(s) '--')"
+                  "text": "Wrong Display Name 'Laboratory test finding (finding)' for http://snomed.info/sct#118246004. Valid display is one of 4 choices: 'Laboratory test finding', 'Laboratory test observations', 'Laboratory test result' or 'Laboratory test finding (navigational concept)' (for the language(s) 'en-US)"
                 },
                 "diagnostics": "[7,15]",
                 "expression": [
@@ -3311,7 +3311,7 @@
                 "severity": "error",
                 "code": "invalid",
                 "details": {
-                  "text": "Wrong Display Name 'Chemistry' for http://snomed.info/sct#275711006. Valid display is one of 2 choices: 'Serum chemistry test' or 'Serum chemistry test (procedure)' (for the language(s) '--')"
+                  "text": "Wrong Display Name 'Chemistry' for http://snomed.info/sct#275711006. Valid display is one of 2 choices: 'Serum chemistry test' or 'Serum chemistry test (procedure)' (for the language(s) 'en-US')"
                 },
                 "diagnostics": "[14,15]",
                 "expression": [
@@ -3347,7 +3347,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Laboratory test finding (finding)' for http://snomed.info/sct#118246004. Valid display is one of 4 choices: 'Laboratory test finding', 'Laboratory test observations', 'Laboratory test result' or 'Laboratory test finding (navigational concept)' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Laboratory test finding (finding)' for http://snomed.info/sct#118246004. Valid display is one of 4 choices: 'Laboratory test finding', 'Laboratory test observations', 'Laboratory test result' or 'Laboratory test finding (navigational concept)' (for the language(s) 'en-US')"
               },
               "diagnostics": "[7,15]",
               "expression": [
@@ -3375,7 +3375,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Chemistry' for http://snomed.info/sct#275711006. Valid display is one of 2 choices: 'Serum chemistry test' or 'Serum chemistry test (procedure)' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Chemistry' for http://snomed.info/sct#275711006. Valid display is one of 2 choices: 'Serum chemistry test' or 'Serum chemistry test (procedure)' (for the language(s) 'en-US')"
               },
               "diagnostics": "[14,15]",
               "expression": [
@@ -3456,7 +3456,7 @@
                 "severity": "error",
                 "code": "invalid",
                 "details": {
-                  "text": "Wrong Display Name 'Laboratory test finding (finding)' for http://snomed.info/sct#118246004. Valid display is one of 4 choices: 'Laboratory test finding', 'Laboratory test observations', 'Laboratory test result' or 'Laboratory test finding (navigational concept)' (for the language(s) '--')"
+                  "text": "Wrong Display Name 'Laboratory test finding (finding)' for http://snomed.info/sct#118246004. Valid display is one of 4 choices: 'Laboratory test finding', 'Laboratory test observations', 'Laboratory test result' or 'Laboratory test finding (navigational concept)' (for the language(s) 'en-US')"
                 },
                 "diagnostics": "[7,15]",
                 "expression": [
@@ -3509,7 +3509,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Laboratory test finding (finding)' for http://snomed.info/sct#118246004. Valid display is one of 4 choices: 'Laboratory test finding', 'Laboratory test observations', 'Laboratory test result' or 'Laboratory test finding (navigational concept)' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Laboratory test finding (finding)' for http://snomed.info/sct#118246004. Valid display is one of 4 choices: 'Laboratory test finding', 'Laboratory test observations', 'Laboratory test result' or 'Laboratory test finding (navigational concept)' (for the language(s) 'en-US')"
               },
               "diagnostics": "[7,15]",
               "expression": [
@@ -3663,7 +3663,7 @@
                 "severity": "error",
                 "code": "invalid",
                 "details": {
-                  "text": "Wrong Display Name 'Chemistry' for http://snomed.info/sct#275711006. Valid display is one of 2 choices: 'Serum chemistry test' or 'Serum chemistry test (procedure)' (for the language(s) '--')"
+                  "text": "Wrong Display Name 'Chemistry' for http://snomed.info/sct#275711006. Valid display is one of 2 choices: 'Serum chemistry test' or 'Serum chemistry test (procedure)' (for the language(s) 'en-US')"
                 },
                 "diagnostics": "[14,15]",
                 "expression": [
@@ -3727,7 +3727,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Chemistry' for http://snomed.info/sct#275711006. Valid display is one of 2 choices: 'Serum chemistry test' or 'Serum chemistry test (procedure)' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Chemistry' for http://snomed.info/sct#275711006. Valid display is one of 2 choices: 'Serum chemistry test' or 'Serum chemistry test (procedure)' (for the language(s) 'en-US')"
               },
               "diagnostics": "[14,15]",
               "expression": [

--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -3294,7 +3294,7 @@
                 "severity": "error",
                 "code": "invalid",
                 "details": {
-                  "text": "Wrong Display Name 'Laboratory test finding (finding)' for http://snomed.info/sct#118246004. Valid display is one of 4 choices: 'Laboratory test finding', 'Laboratory test observations', 'Laboratory test result' or 'Laboratory test finding (navigational concept)' (for the language(s) 'en-US)"
+                  "text": "Wrong Display Name 'Laboratory test finding (finding)' for http://snomed.info/sct#118246004. Valid display is one of 4 choices: 'Laboratory test finding', 'Laboratory test observations', 'Laboratory test result' or 'Laboratory test finding (navigational concept)' (for the language(s) 'en-US')"
                 },
                 "diagnostics": "[7,15]",
                 "expression": [
@@ -3473,7 +3473,7 @@
                 "severity": "error",
                 "code": "invalid",
                 "details": {
-                  "text": "Wrong Display Name 'Chemistry' for http://snomed.info/sct#275711006. Valid display is one of 2 choices: 'Serum chemistry test' or 'Serum chemistry test (procedure)' (for the language(s) '--')"
+                  "text": "Wrong Display Name 'Chemistry' for http://snomed.info/sct#275711006. Valid display is one of 2 choices: 'Serum chemistry test' or 'Serum chemistry test (procedure)' (for the language(s) 'en-US')"
                 },
                 "diagnostics": "[14,15]",
                 "expression": [
@@ -3537,7 +3537,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Chemistry' for http://snomed.info/sct#275711006. Valid display is one of 2 choices: 'Serum chemistry test' or 'Serum chemistry test (procedure)' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Chemistry' for http://snomed.info/sct#275711006. Valid display is one of 2 choices: 'Serum chemistry test' or 'Serum chemistry test (procedure)' (for the language(s) 'en-US')"
               },
               "diagnostics": "[14,15]",
               "expression": [
@@ -23899,7 +23899,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Moderate' for http://snomed.info/sct#6736007. Valid display is one of 4 choices: 'Midgrade', 'Moderate (severity modifier) (qualifier value)', 'Moderate (severity modifier)' or 'Moderate severity' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Moderate' for http://snomed.info/sct#6736007. Valid display is one of 4 choices: 'Midgrade', 'Moderate (severity modifier) (qualifier value)', 'Moderate (severity modifier)' or 'Moderate severity' (for the language(s) 'en-US')"
               },
               "diagnostics": "[1667,6]",
               "expression": [
@@ -35419,7 +35419,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Provider identifier' for http://terminology.hl7.org/CodeSystem/v2-0203#PRN. Valid display is 'Provider number' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Provider identifier' for http://terminology.hl7.org/CodeSystem/v2-0203#PRN. Valid display is 'Provider number' (for the language(s) 'en-US')"
               },
               "diagnostics": "[373,14]",
               "expression": [
@@ -35664,7 +35664,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Patient Authorization Signature' for http://loinc.org#59284-0. Valid display is one of 29 choices: 'Consent Document', 'Consent' (en-US), '临床文档型' (zh-CN), '临床文档' (zh-CN), '文档' (zh-CN), '文书' (zh-CN), '医疗文书' (zh-CN), '临床医疗文书 事件发生的地方' (zh-CN), '场景' (zh-CN), '环境' (zh-CN), '背景 医疗服务对象' (zh-CN), '客户' (zh-CN), '病人' (zh-CN), '超系统 - 病人 发现是一个原子型临床观察指标，并不是作为印象的概括陈述。体格检查、病史、系统检查及其他此类观察指标的属性均为发现。它们的标尺对于编码型发现可能是名义型，而对于叙述型文本之中所报告的发现，则可能是叙述型。' (zh-CN), '发现物' (zh-CN), '所见' (zh-CN), '结果' (zh-CN), '结论 同意书' (zh-CN), '知情同意' (zh-CN), '知情同意书 文档本体' (zh-CN), '临床文档本体' (zh-CN), '文档本体' (zh-CN), '文书本体' (zh-CN), '医疗文书本体' (zh-CN), '临床医疗文书本体 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间' (zh-CN) or 'Documentazione dell'ontologia Osservazione Punto nel tempo (episodio)' (it-IT) (for the language(s) '--')"
+                "text": "Wrong Display Name 'Patient Authorization Signature' for http://loinc.org#59284-0. Valid display is 'Consent Document' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[641,12]",
               "expression": [
@@ -39490,7 +39490,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'O2 % BldC Oximetry' for http://loinc.org#59408-5. Valid display is one of 26 choices: 'Oxygen saturation in Arterial blood by Pulse oximetry', 'SaO2 % BldA PulseOx' (en-US), 'O2 SaO2' (pl-PL), 'saturacja krwi tlenem' (pl-PL), 'MFr O2' (zh-CN), 'tO2' (zh-CN), '总氧' (zh-CN), '氧气 SaO2 动脉血 动脉血O2饱和度 可用数量表示的' (zh-CN), '定量性' (zh-CN), '数值型' (zh-CN), '数量型' (zh-CN), '连续数值型标尺 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 肺部测量指标与呼吸机管理 脉搏血氧测定法' (zh-CN), '脉搏血氧定量' (zh-CN), '脉搏血氧测定' (zh-CN), '脉搏血氧仪 血氧测定法 饱和 饱和状态 饱和程度' (zh-CN), 'O2-Sättigung' (de-DE), 'Frazione di massa Gestione ventilazione polmonare Punto nel tempo (episodio) Sangue arterioso' (it-IT), 'Oksijen doymuşluğu' (tr-TR), 'Количественный Кровь артериальная Массовая доля Насыщение кислородом Оксигемометрия' (ru-RU), 'Гемоксиметрия Точка во времени' (ru-RU), 'Момент' (ru-RU), 'zuurstofsaturatiemeting' (nl-NL) or 'O2 SatO2' (fr-BE) (for the language(s) '--')"
+                "text": "Wrong Display Name 'O2 % BldC Oximetry' for http://loinc.org#59408-5. Valid display is 'Oxygen saturation in Arterial blood by Pulse oximetry' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[44,10]",
               "expression": [
@@ -39529,7 +39529,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Flow Rate' for http://loinc.org#3151-8. Valid display is one of 37 choices: 'Inhaled oxygen flow rate', 'Inhaled O2 flow rate' (en-US), 'O2' (zh-CN), 'tO2' (zh-CN), '总氧' (zh-CN), '氧气 体积速率(单位时间)' (zh-CN), '单位时间内体积的变化速率' (zh-CN), '流量 可用数量表示的' (zh-CN), '定量性' (zh-CN), '数值型' (zh-CN), '数量型' (zh-CN), '连续数值型标尺 吸入气' (zh-CN), '吸入气体' (zh-CN), '吸入的空气 所吸入的氧' (zh-CN), '已吸入的氧气 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 气 气体类 空气' (zh-CN), 'Inhaled O2' (pt-BR), 'vRate' (pt-BR), 'Volume rate' (pt-BR), 'Flow' (pt-BR), 'Point in time' (pt-BR), 'Random' (pt-BR), 'IhG' (pt-BR), 'Inhaled Gas' (pt-BR), 'Inspired' (pt-BR), 'Quantitative' (pt-BR), 'QNT' (pt-BR), 'Quant' (pt-BR), 'Quan' (pt-BR), 'Gases' (pt-BR), 'Clinico Gas inalati Punto nel tempo (episodio) Tasso di Volume' (it-IT), 'Количественный Объемная скорость Точка во времени' (ru-RU), 'Момент' (ru-RU), 'ingeademde O2' (nl-NL) or 'O2-Zufuhr' (de-AT) (for the language(s) '--')"
+                "text": "Wrong Display Name 'Flow Rate' for http://loinc.org#3151-8. Valid display is 'Inhaled oxygen flow rate' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[106,14]",
               "expression": [
@@ -39579,7 +39579,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'O2 % BldC Oximetry' for http://loinc.org#59408-5. Valid display is one of 26 choices: 'Oxygen saturation in Arterial blood by Pulse oximetry', 'SaO2 % BldA PulseOx' (en-US), 'O2 SaO2' (pl-PL), 'saturacja krwi tlenem' (pl-PL), 'MFr O2' (zh-CN), 'tO2' (zh-CN), '总氧' (zh-CN), '氧气 SaO2 动脉血 动脉血O2饱和度 可用数量表示的' (zh-CN), '定量性' (zh-CN), '数值型' (zh-CN), '数量型' (zh-CN), '连续数值型标尺 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 肺部测量指标与呼吸机管理 脉搏血氧测定法' (zh-CN), '脉搏血氧定量' (zh-CN), '脉搏血氧测定' (zh-CN), '脉搏血氧仪 血氧测定法 饱和 饱和状态 饱和程度' (zh-CN), 'O2-Sättigung' (de-DE), 'Frazione di massa Gestione ventilazione polmonare Punto nel tempo (episodio) Sangue arterioso' (it-IT), 'Oksijen doymuşluğu' (tr-TR), 'Количественный Кровь артериальная Массовая доля Насыщение кислородом Оксигемометрия' (ru-RU), 'Гемоксиметрия Точка во времени' (ru-RU), 'Момент' (ru-RU), 'zuurstofsaturatiemeting' (nl-NL) or 'O2 SatO2' (fr-BE) (for the language(s) '--')"
+                "text": "Wrong Display Name 'O2 % BldC Oximetry' for http://loinc.org#59408-5. Valid display is 'Oxygen saturation in Arterial blood by Pulse oximetry' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[156,10]",
               "expression": [
@@ -39629,7 +39629,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Flow Rate' for http://loinc.org#3151-8. Valid display is one of 37 choices: 'Inhaled oxygen flow rate', 'Inhaled O2 flow rate' (en-US), 'O2' (zh-CN), 'tO2' (zh-CN), '总氧' (zh-CN), '氧气 体积速率(单位时间)' (zh-CN), '单位时间内体积的变化速率' (zh-CN), '流量 可用数量表示的' (zh-CN), '定量性' (zh-CN), '数值型' (zh-CN), '数量型' (zh-CN), '连续数值型标尺 吸入气' (zh-CN), '吸入气体' (zh-CN), '吸入的空气 所吸入的氧' (zh-CN), '已吸入的氧气 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 气 气体类 空气' (zh-CN), 'Inhaled O2' (pt-BR), 'vRate' (pt-BR), 'Volume rate' (pt-BR), 'Flow' (pt-BR), 'Point in time' (pt-BR), 'Random' (pt-BR), 'IhG' (pt-BR), 'Inhaled Gas' (pt-BR), 'Inspired' (pt-BR), 'Quantitative' (pt-BR), 'QNT' (pt-BR), 'Quant' (pt-BR), 'Quan' (pt-BR), 'Gases' (pt-BR), 'Clinico Gas inalati Punto nel tempo (episodio) Tasso di Volume' (it-IT), 'Количественный Объемная скорость Точка во времени' (ru-RU), 'Момент' (ru-RU), 'ingeademde O2' (nl-NL) or 'O2-Zufuhr' (de-AT) (for the language(s) '--')"
+                "text": "Wrong Display Name 'Flow Rate' for http://loinc.org#3151-8. Valid display is 'Inhaled oxygen flow rate' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[212,14]",
               "expression": [

--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -10848,7 +10848,7 @@
               "severity": "error",
               "code": "code-invalid",
               "details": {
-                "text": "Unknown code '�g��' in the CodeSystem 'http://loinc.org' version '2.74'"
+                "text": "Unknown code '�g��' in the CodeSystem 'http://loinc.org' version '2.77'"
               },
               "diagnostics": "[277,15]",
               "expression": [
@@ -10949,7 +10949,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name '����' for http://loinc.org#18684-1. Valid display is 'First Blood pressure Set' (for the language(s) 'en')"
+                "text": "Wrong Display Name '����' for http://loinc.org#18684-1. Valid display is 'First Blood pressure Set' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[383,15]",
               "expression": [
@@ -10976,7 +10976,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name '���k������' for http://loinc.org#8480-6. Valid display is one of 2 choices: 'Systolic blood pressure' or 'BP sys' (en-US) (for the language(s) 'en')"
+                "text": "Wrong Display Name '���k������' for http://loinc.org#8480-6. Valid display is 'Systolic blood pressure' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[395,17]",
               "expression": [
@@ -10993,7 +10993,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name '�g��������' for http://loinc.org#8462-4. Valid display is one of 2 choices: 'Diastolic blood pressure' or 'BP dias' (en-US) (for the language(s) 'en')"
+                "text": "Wrong Display Name '�g��������' for http://loinc.org#8462-4. Valid display is 'Diastolic blood pressure' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[409,17]",
               "expression": [
@@ -31073,7 +31073,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'X SARS-COV-2 (COVID-19) vaccine, mRNA, spike protein, LNP, preservative free, 100 mcg/0.5mL dose' for http://hl7.org/fhir/sid/cvx#207. Valid display is 'COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5mL dose or 50 mcg/0.25mL dose' (for the language(s) '--')"
+                "text": "Wrong Display Name 'X SARS-COV-2 (COVID-19) vaccine, mRNA, spike protein, LNP, preservative free, 100 mcg/0.5mL dose' for http://hl7.org/fhir/sid/cvx#207. Valid display is 'COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5mL dose or 50 mcg/0.25mL dose' (for the language(s) 'en-US')"
               },
               "diagnostics": "[4,4]",
               "expression": [
@@ -31173,7 +31173,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'SARS-COV-2 (COVID-19) vaccine, mRNA, spike protein, LNP, preservative free, 100 mcg/0.5mL dose' for http://hl7.org/fhir/sid/cvx#207. Valid display is 'COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5mL dose or 50 mcg/0.25mL dose' (for the language(s) '--')"
+                "text": "Wrong Display Name 'SARS-COV-2 (COVID-19) vaccine, mRNA, spike protein, LNP, preservative free, 100 mcg/0.5mL dose' for http://hl7.org/fhir/sid/cvx#207. Valid display is 'COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5mL dose or 50 mcg/0.25mL dose' (for the language(s) 'en-US')"
               },
               "diagnostics": "[13,10]",
               "expression": [
@@ -31225,7 +31225,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'SARS-COV-2 (COVID-19) vaccine, mRNA, spike protein, LNP, preservative free, 100 mcg/0.5mL dose' for http://hl7.org/fhir/sid/cvx#207. Valid display is 'COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5mL dose or 50 mcg/0.25mL dose' (for the language(s) '--')"
+                "text": "Wrong Display Name 'SARS-COV-2 (COVID-19) vaccine, mRNA, spike protein, LNP, preservative free, 100 mcg/0.5mL dose' for http://hl7.org/fhir/sid/cvx#207. Valid display is 'COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5mL dose or 50 mcg/0.25mL dose' (for the language(s) 'en-US')"
               },
               "diagnostics": "[13,10]",
               "expression": [
@@ -31288,7 +31288,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'SARS-COV-2 (COVID-19) vaccine, mRNA, spike protein, LNP, preservative free, 100 mcg/0.5mL dose' for http://hl7.org/fhir/sid/cvx#207. Valid display is 'COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5mL dose or 50 mcg/0.25mL dose' (for the language(s) '--')"
+                "text": "Wrong Display Name 'SARS-COV-2 (COVID-19) vaccine, mRNA, spike protein, LNP, preservative free, 100 mcg/0.5mL dose' for http://hl7.org/fhir/sid/cvx#207. Valid display is 'COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5mL dose or 50 mcg/0.25mL dose' (for the language(s) 'en-US')"
               },
               "diagnostics": "[9,10]",
               "expression": [
@@ -36711,7 +36711,7 @@
               "severity": "warning",
               "code": "not-found",
               "details": {
-                "text": "A definition for CodeSystem 'http://terminology.hl7.org/CodeSystem/condition-clinical' version '0.5.0' could not be found, so the code cannot be validated. Valid versions: [2.0.0,4.0.1] (error because this is a required binding)"
+                "text": "A definition for CodeSystem 'http://terminology.hl7.org/CodeSystem/condition-clinical' version '0.5.0' could not be found, so the code cannot be validated. Valid versions: [3.0.0,4.0.1] (error because this is a required binding)"
               },
               "diagnostics": "[51,21]",
               "expression": [

--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -5140,7 +5140,7 @@
               "severity": "information",
               "code": "not-found",
               "details": {
-                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/731000124108/version/20210201' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20230901,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
+                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/731000124108/version/20210201' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20240301,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
               },
               "diagnostics": "[2,9]",
               "expression": [
@@ -5199,7 +5199,7 @@
               "severity": "information",
               "code": "not-found",
               "details": {
-                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/11000172109/version/20221115' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20230901,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
+                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/11000172109/version/20221115' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20240301,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
               },
               "diagnostics": "[2,9]",
               "expression": [
@@ -8277,7 +8277,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Cholesterol [Moles/\u200Bvolume] in Serum or Plasma' for http://loinc.org#35200-5. Valid display is 'Cholesterol [Mass or Moles/volume] in Serum or Plasma' (en-US) (for the language(s) 'en-US')"
+                "text": "Wrong Display Name 'Cholesterol [Moles/​volume] in Serum or Plasma' for http://loinc.org#35200-5. Valid display is 'Cholesterol [Mass or Moles/volume] in Serum or Plasma' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[66,8]",
               "expression": [
@@ -8305,7 +8305,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Cholesterol [Moles/\u200Bvolume] in Serum or Plasma' for http://loinc.org#35200-5. Valid display is 'Cholesterol [Mass or Moles/volume] in Serum or Plasma' (en-US) (for the language(s) 'en-US')"
+                "text": "Wrong Display Name 'Cholesterol [Moles/​volume] in Serum or Plasma' for http://loinc.org#35200-5. Valid display is 'Cholesterol [Mass or Moles/volume] in Serum or Plasma' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[66,8]",
               "expression": [
@@ -8355,7 +8355,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Cholesterol [Moles/\u200Bvolume] in Serum or Plasma' for http://loinc.org#35200-5. Valid display is 'Cholesterol [Mass or Moles/volume] in Serum or Plasma' (en-US) (for the language(s) 'en-US')"
+                "text": "Wrong Display Name 'Cholesterol [Moles/​volume] in Serum or Plasma' for http://loinc.org#35200-5. Valid display is 'Cholesterol [Mass or Moles/volume] in Serum or Plasma' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[67,8]",
               "expression": [
@@ -8547,7 +8547,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Triglyceride [Moles/\u200Bvolume] in Serum or Plasma' for http://loinc.org#35217-9. Valid display is 'Triglyceride [Mass or Moles/volume] in Serum or Plasma' (en-US) (for the language(s) 'en-US')"
+                "text": "Wrong Display Name 'Triglyceride [Moles/​volume] in Serum or Plasma' for http://loinc.org#35217-9. Valid display is 'Triglyceride [Mass or Moles/volume] in Serum or Plasma' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[67,8]",
               "expression": [
@@ -8575,7 +8575,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Triglyceride [Moles/\u200Bvolume] in Serum or Plasma' for http://loinc.org#35217-9. Valid display is 'Triglyceride [Mass or Moles/volume] in Serum or Plasma' (en-US) (for the language(s) 'en-US')"
+                "text": "Wrong Display Name 'Triglyceride [Moles/​volume] in Serum or Plasma' for http://loinc.org#35217-9. Valid display is 'Triglyceride [Mass or Moles/volume] in Serum or Plasma' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[67,8]",
               "expression": [
@@ -13498,7 +13498,7 @@
               "severity": "information",
               "code": "not-found",
               "details": {
-                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/11000146104/version/20220930' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20230901,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
+                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/11000146104/version/20220930' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20240301,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
               },
               "diagnostics": "[6,4]",
               "expression": [
@@ -26808,12 +26808,6 @@
               ]
             },
             {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-server",
-                  "valueUrl": "http://tx-dev.fhir.org/r4"
-                }
-              ],
               "severity": "information",
               "code": "not-found",
               "details": {
@@ -26821,16 +26815,10 @@
               },
               "diagnostics": "[1102,14]",
               "expression": [
-                "Bundle.entry[12].resource.contained[0]/*Medication/mni-medication-example2*/.code.coding[0].system"
+                "Bundle.entry[12].resource.contained[0]/*Medication/mni-medication-example2*/.code.coding[0]"
               ]
             },
             {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-server",
-                  "valueUrl": "http://tx-dev.fhir.org/r4"
-                }
-              ],
               "severity": "information",
               "code": "not-found",
               "details": {
@@ -26838,16 +26826,10 @@
               },
               "diagnostics": "[1102,14]",
               "expression": [
-                "Bundle.entry[12].resource.contained[0]/*Medication/mni-medication-example2*/.code.coding[1].system"
+                "Bundle.entry[12].resource.contained[0]/*Medication/mni-medication-example2*/.code.coding[1]"
               ]
             },
             {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-server",
-                  "valueUrl": "http://tx-dev.fhir.org/r4"
-                }
-              ],
               "severity": "information",
               "code": "not-found",
               "details": {
@@ -26855,7 +26837,7 @@
               },
               "diagnostics": "[1102,14]",
               "expression": [
-                "Bundle.entry[12].resource.contained[0]/*Medication/mni-medication-example2*/.code.coding[2].system"
+                "Bundle.entry[12].resource.contained[0]/*Medication/mni-medication-example2*/.code.coding[2]"
               ]
             },
             {
@@ -30877,23 +30859,6 @@
                   "valueUrl": "http://tx-dev.fhir.org/r4"
                 }
               ],
-              "severity": "information",
-              "code": "business-rule",
-              "details": {
-                "text": "Reference to experimental CodeSystem http://hl7.org/fhir/sid/icd-10|2019-covid-expanded"
-              },
-              "diagnostics": "[126,4]",
-              "expression": [
-                "MedicationRequest.reasonCode[0]"
-              ]
-            },
-            {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-server",
-                  "valueUrl": "http://tx-dev.fhir.org/r4"
-                }
-              ],
               "severity": "error",
               "code": "invalid",
               "details": {
@@ -32896,7 +32861,7 @@
               "severity": "information",
               "code": "not-found",
               "details": {
-                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20210331' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20230901,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
+                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20210331' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20240301,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
               },
               "diagnostics": "[4,4]",
               "expression": [
@@ -34119,23 +34084,6 @@
               ]
             },
             {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-server",
-                  "valueUrl": "http://tx-dev.fhir.org/r4"
-                }
-              ],
-              "severity": "information",
-              "code": "business-rule",
-              "details": {
-                "text": "Reference to experimental CodeSystem http://hl7.org/fhir/sid/icd-10|2019-covid-expanded"
-              },
-              "diagnostics": "[274,22]",
-              "expression": [
-                "Bundle.entry[2].resource/*DiagnosticReport/1*/.conclusionCode[0]"
-              ]
-            },
-            {
               "severity": "error",
               "code": "structure",
               "details": {
@@ -34330,7 +34278,7 @@
               "extension": [
                 {
                   "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-slicetext",
-                  "valueString": "Bundle.entry[1]: Does not match slice 'Colonoscopy' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-colonoscopy-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.extension[6].value.ofType(CodeableConcept).coding[0].code: Unknown code '10821000202101' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.extension[6].value.ofType(CodeableConcept): None of the codings provided are in the value set 'Colonoscopy Report Sedation Level' (http://ehelse.no/fhir/ValueSet/no-colonoscopy-sedation-level), and a coding from this value set is required) (codes = http://snomed.info/sct#10821000202101); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.category.coding[0].display: Wrong Display Name 'Diagnostisk med biopsi' for http://snomed.info/sct#446745002. Valid display is one of 2 choices: 'Colonoscopy and biopsy of colon (procedure)' or 'Colonoscopy and biopsy of colon' (for the language(s) '--'); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.category: None of the codings provided are in the value set 'Colonoscopy Type' (http://ehelse.no/fhir/ValueSet/no-colonoscopy-type), and a coding from this value set is required) (codes = http://snomed.info/sct#446745002); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[0].function.coding[0].code: Unknown code '8921000202108' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[0].function: None of the codings provided are in the value set 'Conoloscopy Report Performer Function' (http://ehelse.no/fhir/ValueSet/no-procedure-performer-function), and a coding from this value set is required) (codes = http://snomed.info/sct#8921000202108); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[1].function.coding[0].code: Unknown code '8951000202101' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[1].function: None of the codings provided are in the value set 'Conoloscopy Report Performer Function' (http://ehelse.no/fhir/ValueSet/no-procedure-performer-function), and a coding from this value set is required) (codes = http://snomed.info/sct#8951000202101); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Unable to find a match for profile http://testdata.no/fhir/DiagnosticReport/1 among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-diagnosticreport-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Unable to find a match for profile http://testdata.no/fhir/Observation/lesion-1 among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lesion-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Bundle.entry[4].resource/*Observation/lesion-1*/.component[0].code.coding[0].code: Unknown code '10291000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Bundle.entry[4].resource/*Observation/lesion-1*/.component[0].code.coding[0].code: Unknown code '10291000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Unable to find a match for profile http://testdata.no/fhir/Observation/bbps among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-bostonbowelpreparationscale-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[0].code.coding[0].code: Unknown code '8901000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[1].code.coding[0].code: Unknown code '8911000202100' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[2].code.coding[0].code: Unknown code '8891000202103' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[0].code.coding[0].code: Unknown code '8901000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[1].code.coding[0].code: Unknown code '8911000202100' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[2].code.coding[0].code: Unknown code '8891000202103' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Unable to find a match for profile http://testdata.no/fhir/Observation/lumen among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lumen-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Bundle.entry[6].resource/*Observation/lumen*/.code.coding[0].code: Unknown code '15991000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Bundle.entry[6].resource/*Observation/lumen*/.code.coding[0].code: Unknown code '15991000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Does not match slice 'SubProcedure' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Procedure.category: max allowed = 0, but found 1 (from http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet); Bundle.entry[1]: Bundle.entry[1].resource: Procedure.performed[x]: max allowed = 0, but found 1 (from http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet); Bundle.entry[1]: Bundle.entry[1].resource: Procedure.performer: max allowed = 0, but found 2 (from http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet); Bundle.entry[1]: Bundle.entry[1].resource: Procedure.location: max allowed = 0, but found 1 (from http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet); Bundle.entry[1]: Bundle.entry[1].resource: Procedure.reasonCode: max allowed = 0, but found 1 (from http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet); Bundle.entry[1]: Bundle.entry[1].resource: Procedure.report: max allowed = 0, but found 1 (from http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet); Bundle.entry[1]: Bundle.entry[1].resource: Procedure.complication: max allowed = 0, but found 1 (from http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet); Bundle.entry[1]: Bundle.entry[1].resource.extension[6].value.ofType(CodeableConcept).coding[0].code: Unknown code '10821000202101' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.category.coding[0].display: Wrong Display Name 'Diagnostisk med biopsi' for http://snomed.info/sct#446745002. Valid display is one of 2 choices: 'Colonoscopy and biopsy of colon (procedure)' or 'Colonoscopy and biopsy of colon' (for the language(s) '--'); Bundle.entry[1]: Bundle.entry[1].resource.subject: Unable to resolve the profile reference 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lesion-patient'; Bundle.entry[1]: Bundle.entry[1].resource.subject: Invalid Resource target type. Found Patient, but expected one of ([]); Bundle.entry[1]: Bundle.entry[1].resource.performer[0].function.coding[0].code: Unknown code '8921000202108' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.performer[1].function.coding[0].code: Unknown code '8951000202101' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Bundle.entry[4].resource/*Observation/lesion-1*/.component[0].code.coding[0].code: Unknown code '10291000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[0].code.coding[0].code: Unknown code '8901000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[1].code.coding[0].code: Unknown code '8911000202100' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[2].code.coding[0].code: Unknown code '8891000202103' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Bundle.entry[6].resource/*Observation/lumen*/.code.coding[0].code: Unknown code '15991000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Unable to find a match for profile http://testdata.no/fhir/Observation/lesion-1 among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lesion-gastronet; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Bundle.entry[4].resource/*Observation/lesion-1*/.component[0].code.coding[0].code: Unknown code '10291000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Unable to find a match for profile http://testdata.no/fhir/Observation/bbps among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-bostonbowelpreparationscale-gastronet; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[0].code.coding[0].code: Unknown code '8901000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[1].code.coding[0].code: Unknown code '8911000202100' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[2].code.coding[0].code: Unknown code '8891000202103' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Unable to find a match for profile http://testdata.no/fhir/Observation/lumen among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lumen-gastronet; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Bundle.entry[6].resource/*Observation/lumen*/.code.coding[0].code: Unknown code '15991000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.extension[6].value.ofType(CodeableConcept).coding[0].code: Unknown code '10821000202101' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.extension[6].value.ofType(CodeableConcept): None of the codings provided are in the value set 'Colonoscopy Report Sedation Level' (http://ehelse.no/fhir/ValueSet/no-colonoscopy-sedation-level), and a coding from this value set is required) (codes = http://snomed.info/sct#10821000202101); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.category.coding[0].display: Wrong Display Name 'Diagnostisk med biopsi' for http://snomed.info/sct#446745002. Valid display is one of 2 choices: 'Colonoscopy and biopsy of colon (procedure)' or 'Colonoscopy and biopsy of colon' (for the language(s) '--'); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.category: None of the codings provided are in the value set 'Colonoscopy Type' (http://ehelse.no/fhir/ValueSet/no-colonoscopy-type), and a coding from this value set is required) (codes = http://snomed.info/sct#446745002); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[0].function.coding[0].code: Unknown code '8921000202108' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[0].function: None of the codings provided are in the value set 'Conoloscopy Report Performer Function' (http://ehelse.no/fhir/ValueSet/no-procedure-performer-function), and a coding from this value set is required) (codes = http://snomed.info/sct#8921000202108); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[1].function.coding[0].code: Unknown code '8951000202101' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[1].function: None of the codings provided are in the value set 'Conoloscopy Report Performer Function' (http://ehelse.no/fhir/ValueSet/no-procedure-performer-function), and a coding from this value set is required) (codes = http://snomed.info/sct#8951000202101); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Unable to find a match for profile http://testdata.no/fhir/DiagnosticReport/1 among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-diagnosticreport-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Unable to find a match for profile http://testdata.no/fhir/Observation/lesion-1 among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lesion-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Bundle.entry[4].resource/*Observation/lesion-1*/.component[0].code.coding[0].code: Unknown code '10291000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Bundle.entry[4].resource/*Observation/lesion-1*/.component[0].code.coding[0].code: Unknown code '10291000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Unable to find a match for profile http://testdata.no/fhir/Observation/bbps among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-bostonbowelpreparationscale-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[0].code.coding[0].code: Unknown code '8901000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[1].code.coding[0].code: Unknown code '8911000202100' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[2].code.coding[0].code: Unknown code '8891000202103' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[0].code.coding[0].code: Unknown code '8901000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[1].code.coding[0].code: Unknown code '8911000202100' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[2].code.coding[0].code: Unknown code '8891000202103' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Unable to find a match for profile http://testdata.no/fhir/Observation/lumen among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lumen-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Bundle.entry[6].resource/*Observation/lumen*/.code.coding[0].code: Unknown code '15991000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Bundle.entry[6].resource/*Observation/lumen*/.code.coding[0].code: Unknown code '15991000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Does not match slice 'MedicationStatement' (discriminator: resource.conformsTo('http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-medicationstatement')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'MedicationStatement' in profile 'http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-medicationstatement', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'ProblemList' (discriminator: resource.conformsTo('http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-problemlist')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'List' in profile 'http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-problemlist', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'MedicationList' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-medicationlist-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'List' in profile 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-medicationlist-gastronet', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'DiagnosticReport' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-diagnosticreport-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'DiagnosticReport' in profile 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-diagnosticreport-gastronet', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'Lesion' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lesion-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'Observation' in profile 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lesion-gastronet', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'NumberOfLesions' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-numberoflesions-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'Observation' in profile 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-numberoflesions-gastronet', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'BostonBowelPreparationScale' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-bostonbowelpreparationscale-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'Observation' in profile 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-bostonbowelpreparationscale-gastronet', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'Lumen' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lumen-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'Observation' in profile 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lumen-gastronet', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'Patient' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-patient-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'Patient' in profile 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-patient-gastronet', but found type 'Procedure'"
+                  "valueString": "Bundle.entry[1]: Does not match slice 'Colonoscopy' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-colonoscopy-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.extension[6].value.ofType(CodeableConcept).coding[0].code: Unknown code '10821000202101' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.extension[6].value.ofType(CodeableConcept): None of the codings provided are in the value set 'Colonoscopy Report Sedation Level' (http://ehelse.no/fhir/ValueSet/no-colonoscopy-sedation-level), and a coding from this value set is required) (codes = http://snomed.info/sct#10821000202101); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.category.coding[0].display: Wrong Display Name 'Diagnostisk med biopsi' for http://snomed.info/sct#446745002. Valid display is one of 2 choices: 'Colonoscopy and biopsy of colon (procedure)' or 'Colonoscopy and biopsy of colon' (for the language(s) 'en-US'); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.category: None of the codings provided are in the value set 'Colonoscopy Type' (http://ehelse.no/fhir/ValueSet/no-colonoscopy-type), and a coding from this value set is required) (codes = http://snomed.info/sct#446745002); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[0].function.coding[0].code: Unknown code '8921000202108' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[0].function: None of the codings provided are in the value set 'Conoloscopy Report Performer Function' (http://ehelse.no/fhir/ValueSet/no-procedure-performer-function), and a coding from this value set is required) (codes = http://snomed.info/sct#8921000202108); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[1].function.coding[0].code: Unknown code '8951000202101' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[1].function: None of the codings provided are in the value set 'Conoloscopy Report Performer Function' (http://ehelse.no/fhir/ValueSet/no-procedure-performer-function), and a coding from this value set is required) (codes = http://snomed.info/sct#8951000202101); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Unable to find a match for profile http://testdata.no/fhir/DiagnosticReport/1 among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-diagnosticreport-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Unable to find a match for profile http://testdata.no/fhir/Observation/lesion-1 among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lesion-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Bundle.entry[4].resource/*Observation/lesion-1*/.component[0].code.coding[0].code: Unknown code '10291000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Bundle.entry[4].resource/*Observation/lesion-1*/.component[0].code.coding[0].code: Unknown code '10291000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Unable to find a match for profile http://testdata.no/fhir/Observation/bbps among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-bostonbowelpreparationscale-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[0].code.coding[0].code: Unknown code '8901000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[1].code.coding[0].code: Unknown code '8911000202100' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[2].code.coding[0].code: Unknown code '8891000202103' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[0].code.coding[0].code: Unknown code '8901000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[1].code.coding[0].code: Unknown code '8911000202100' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[2].code.coding[0].code: Unknown code '8891000202103' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Unable to find a match for profile http://testdata.no/fhir/Observation/lumen among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lumen-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Bundle.entry[6].resource/*Observation/lumen*/.code.coding[0].code: Unknown code '15991000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Bundle.entry[6].resource/*Observation/lumen*/.code.coding[0].code: Unknown code '15991000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Does not match slice 'SubProcedure' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Procedure.category: max allowed = 0, but found 1 (from http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet); Bundle.entry[1]: Bundle.entry[1].resource: Procedure.performed[x]: max allowed = 0, but found 1 (from http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet); Bundle.entry[1]: Bundle.entry[1].resource: Procedure.performer: max allowed = 0, but found 2 (from http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet); Bundle.entry[1]: Bundle.entry[1].resource: Procedure.location: max allowed = 0, but found 1 (from http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet); Bundle.entry[1]: Bundle.entry[1].resource: Procedure.reasonCode: max allowed = 0, but found 1 (from http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet); Bundle.entry[1]: Bundle.entry[1].resource: Procedure.report: max allowed = 0, but found 1 (from http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet); Bundle.entry[1]: Bundle.entry[1].resource: Procedure.complication: max allowed = 0, but found 1 (from http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-subprocedure-gastronet); Bundle.entry[1]: Bundle.entry[1].resource.extension[6].value.ofType(CodeableConcept).coding[0].code: Unknown code '10821000202101' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.category.coding[0].display: Wrong Display Name 'Diagnostisk med biopsi' for http://snomed.info/sct#446745002. Valid display is one of 2 choices: 'Colonoscopy and biopsy of colon (procedure)' or 'Colonoscopy and biopsy of colon' (for the language(s) 'en-US'); Bundle.entry[1]: Bundle.entry[1].resource.subject: Unable to resolve the profile reference 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lesion-patient'; Bundle.entry[1]: Bundle.entry[1].resource.subject: Invalid Resource target type. Found Patient, but expected one of ([]); Bundle.entry[1]: Bundle.entry[1].resource.performer[0].function.coding[0].code: Unknown code '8921000202108' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.performer[1].function.coding[0].code: Unknown code '8951000202101' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Bundle.entry[4].resource/*Observation/lesion-1*/.component[0].code.coding[0].code: Unknown code '10291000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[0].code.coding[0].code: Unknown code '8901000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[1].code.coding[0].code: Unknown code '8911000202100' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[2].code.coding[0].code: Unknown code '8891000202103' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Bundle.entry[6].resource/*Observation/lumen*/.code.coding[0].code: Unknown code '15991000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Unable to find a match for profile http://testdata.no/fhir/Observation/lesion-1 among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lesion-gastronet; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Bundle.entry[4].resource/*Observation/lesion-1*/.component[0].code.coding[0].code: Unknown code '10291000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Unable to find a match for profile http://testdata.no/fhir/Observation/bbps among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-bostonbowelpreparationscale-gastronet; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[0].code.coding[0].code: Unknown code '8901000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[1].code.coding[0].code: Unknown code '8911000202100' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[2].code.coding[0].code: Unknown code '8891000202103' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Unable to find a match for profile http://testdata.no/fhir/Observation/lumen among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lumen-gastronet; Bundle.entry[1]: Bundle.entry[1].resource.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Bundle.entry[6].resource/*Observation/lumen*/.code.coding[0].code: Unknown code '15991000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.extension[6].value.ofType(CodeableConcept).coding[0].code: Unknown code '10821000202101' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.extension[6].value.ofType(CodeableConcept): None of the codings provided are in the value set 'Colonoscopy Report Sedation Level' (http://ehelse.no/fhir/ValueSet/no-colonoscopy-sedation-level), and a coding from this value set is required) (codes = http://snomed.info/sct#10821000202101); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.category.coding[0].display: Wrong Display Name 'Diagnostisk med biopsi' for http://snomed.info/sct#446745002. Valid display is one of 2 choices: 'Colonoscopy and biopsy of colon (procedure)' or 'Colonoscopy and biopsy of colon' (for the language(s) 'en-US'); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.category: None of the codings provided are in the value set 'Colonoscopy Type' (http://ehelse.no/fhir/ValueSet/no-colonoscopy-type), and a coding from this value set is required) (codes = http://snomed.info/sct#446745002); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[0].function.coding[0].code: Unknown code '8921000202108' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[0].function: None of the codings provided are in the value set 'Conoloscopy Report Performer Function' (http://ehelse.no/fhir/ValueSet/no-procedure-performer-function), and a coding from this value set is required) (codes = http://snomed.info/sct#8921000202108); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[1].function.coding[0].code: Unknown code '8951000202101' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.performer[1].function: None of the codings provided are in the value set 'Conoloscopy Report Performer Function' (http://ehelse.no/fhir/ValueSet/no-procedure-performer-function), and a coding from this value set is required) (codes = http://snomed.info/sct#8951000202101); Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Unable to find a match for profile http://testdata.no/fhir/DiagnosticReport/1 among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-diagnosticreport-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Unable to find a match for profile http://testdata.no/fhir/Observation/lesion-1 among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lesion-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Bundle.entry[4].resource/*Observation/lesion-1*/.component[0].code.coding[0].code: Unknown code '10291000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[0]: Bundle.entry[4].resource/*Observation/lesion-1*/.component[0].code.coding[0].code: Unknown code '10291000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Unable to find a match for profile http://testdata.no/fhir/Observation/bbps among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-bostonbowelpreparationscale-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[0].code.coding[0].code: Unknown code '8901000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[1].code.coding[0].code: Unknown code '8911000202100' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[2].code.coding[0].code: Unknown code '8891000202103' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[0].code.coding[0].code: Unknown code '8901000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[1].code.coding[0].code: Unknown code '8911000202100' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[1]: Bundle.entry[5].resource/*Observation/bbps*/.component[2].code.coding[0].code: Unknown code '8891000202103' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Unable to find a match for profile http://testdata.no/fhir/Observation/lumen among choices: http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lumen-gastronet; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Bundle.entry[6].resource/*Observation/lumen*/.code.coding[0].code: Unknown code '15991000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Bundle.entry[1].resource/*Procedure/1*/.report[0]: Bundle.entry[2].resource/*DiagnosticReport/1*/.result[3]: Bundle.entry[6].resource/*Observation/lumen*/.code.coding[0].code: Unknown code '15991000202102' in the CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20240201'; Bundle.entry[1]: Does not match slice 'MedicationStatement' (discriminator: resource.conformsTo('http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-medicationstatement')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'MedicationStatement' in profile 'http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-medicationstatement', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'ProblemList' (discriminator: resource.conformsTo('http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-problemlist')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'List' in profile 'http://kreftregisteret.no/fhir/StructureDefinition/colonoscopyreport-problemlist', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'MedicationList' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-medicationlist-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'List' in profile 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-medicationlist-gastronet', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'DiagnosticReport' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-diagnosticreport-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'DiagnosticReport' in profile 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-diagnosticreport-gastronet', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'Lesion' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lesion-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'Observation' in profile 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lesion-gastronet', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'NumberOfLesions' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-numberoflesions-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'Observation' in profile 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-numberoflesions-gastronet', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'BostonBowelPreparationScale' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-bostonbowelpreparationscale-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'Observation' in profile 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-bostonbowelpreparationscale-gastronet', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'Lumen' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lumen-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'Observation' in profile 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-lumen-gastronet', but found type 'Procedure'; Bundle.entry[1]: Does not match slice 'Patient' (discriminator: resource.conformsTo('http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-patient-gastronet')); Bundle.entry[1]: Bundle.entry[1].resource: Specified profile type was 'Patient' in profile 'http://kvalitetsregistre.no/fhir/StructureDefinition/colonoscopyreport-patient-gastronet', but found type 'Procedure'"
                 }
               ],
               "severity": "information",
@@ -34794,7 +34742,7 @@
               "severity": "warning",
               "code": "code-invalid",
               "details": {
-                "text": "The Coding provided (urn:oid:1.2.840.114350.1.72.1.7.7.10.696784.13260#1) was not found in the value set 'ActEncounterCode' (http://terminology.hl7.org/ValueSet/v3-ActEncounterCode|2.0.0), and a code should come from this value set unless it has no suitable code (note that the validator cannot judge what is suitable).  (error message = Error from http://tx-dev.fhir.org/r4: Element name mismatch (start: \"tr\"/ end: \"td\") at Line 168, Column 86)"
+                "text": "The code provided (urn:oid:1.2.840.114350.1.72.1.7.7.10.696784.13260#1) is not in the value set 'ActEncounterCode' (http://terminology.hl7.org/ValueSet/v3-ActEncounterCode|2.0.0), and a code should come from this value set unless it has no suitable code (the validator cannot judge what is suitable)"
               },
               "diagnostics": "[12,4]",
               "expression": [
@@ -36515,14 +36463,20 @@
               ]
             },
             {
-              "severity": "error",
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-server",
+                  "valueUrl": "http://tx-dev.fhir.org/r4"
+                }
+              ],
+              "severity": "warning",
               "code": "not-found",
               "details": {
                 "text": "A definition for CodeSystem 'http://fhir.mimic.mit.edu/CodeSystem/admission-type' could not be found, so the code cannot be validated (error because this is a required binding)"
               },
               "diagnostics": "[1,243]",
               "expression": [
-                "Encounter.type[0].coding[0]"
+                "Encounter.type[0].coding[0].system"
               ]
             },
             {
@@ -36534,28 +36488,6 @@
               "diagnostics": "[1,243]",
               "expression": [
                 "Encounter.type[0]"
-              ]
-            },
-            {
-              "severity": "information",
-              "code": "not-found",
-              "details": {
-                "text": "A definition for CodeSystem 'http://fhir.mimic.mit.edu/CodeSystem/admit-source' could not be found, so the code cannot be validated"
-              },
-              "diagnostics": "[1,899]",
-              "expression": [
-                "Encounter.hospitalization.admitSource.coding[0]"
-              ]
-            },
-            {
-              "severity": "information",
-              "code": "not-found",
-              "details": {
-                "text": "A definition for CodeSystem 'http://fhir.mimic.mit.edu/CodeSystem/discharge-dispostion' could not be found, so the code cannot be validated"
-              },
-              "diagnostics": "[1,1029]",
-              "expression": [
-                "Encounter.hospitalization.dischargeDisposition.coding[0]"
               ]
             }
           ]
@@ -36772,7 +36704,7 @@
               "severity": "information",
               "code": "not-found",
               "details": {
-                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/11000146104/version/20220930' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20230901,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
+                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/11000146104/version/20220930' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20240301,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
               },
               "diagnostics": "[83,29]",
               "expression": [
@@ -36817,7 +36749,7 @@
               "severity": "information",
               "code": "not-found",
               "details": {
-                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/11000146104/version/20220930' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20230901,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
+                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/11000146104/version/20220930' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20240301,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
               },
               "diagnostics": "[101,29]",
               "expression": [
@@ -42064,7 +41996,7 @@
               "severity": "warning",
               "code": "not-found",
               "details": {
-                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20210731' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20230901,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
+                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20210731' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20240301,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
               },
               "diagnostics": "[27,4]",
               "expression": [
@@ -42081,7 +42013,7 @@
               "severity": "information",
               "code": "not-found",
               "details": {
-                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20210731' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20230901,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
+                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20210731' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20240301,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]"
               },
               "diagnostics": "[94,4]",
               "expression": [
@@ -42109,7 +42041,7 @@
               "severity": "error",
               "code": "not-found",
               "details": {
-                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20210731' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20230901,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201] (error because this is a required binding)"
+                "text": "A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20210731' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20240301,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201] (error because this is a required binding)"
               },
               "diagnostics": "[29,8]",
               "expression": [
@@ -42137,7 +42069,7 @@
               "severity": "error",
               "code": "code-invalid",
               "details": {
-                "text": "The code provided (http://snomed.info/sct#27113001) was not found in the value set 'Koerpergroesse' (https://fhir.kbv.de/ValueSet/KBV_VS_Base_Body_Weight_Snomed|1.2.1), and a code from this value set is required: A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20210731' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20230901,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]; Unable to check whether the code is in the value set 'https://fhir.kbv.de/ValueSet/KBV_VS_Base_Body_Weight_Snomed|1.2.1' because the code system http://snomed.info/sct|http://snomed.info/sct/900000000000207008/version/20210731 was not found"
+                "text": "The code provided (http://snomed.info/sct#27113001) was not found in the value set 'Koerpergroesse' (https://fhir.kbv.de/ValueSet/KBV_VS_Base_Body_Weight_Snomed|1.2.1), and a code from this value set is required: A definition for CodeSystem 'http://snomed.info/sct' version 'http://snomed.info/sct/900000000000207008/version/20210731' could not be found, so the code cannot be validated. Valid versions: [http://snomed.info/sct/11000146104/version/20230331,http://snomed.info/sct/11000172109/version/20231115,http://snomed.info/sct/2011000195101/version/20230607,http://snomed.info/sct/20611000087101/version/20220930,http://snomed.info/sct/32506021000036107/version/20230731,http://snomed.info/sct/45991000052106/version/20220531,http://snomed.info/sct/45991000052106/version/20231130,http://snomed.info/sct/554471000005108/version/20210930,http://snomed.info/sct/731000124108/version/20240301,http://snomed.info/sct/827022005/version/20221130,http://snomed.info/sct/83821000000107/version/20230412,http://snomed.info/sct/900000000000207008/version/20230131,http://snomed.info/sct/900000000000207008/version/20230731,http://snomed.info/sct/900000000000207008/version/20240201]; Unable to check whether the code is in the value set 'https://fhir.kbv.de/ValueSet/KBV_VS_Base_Body_Weight_Snomed|1.2.1' because the code system http://snomed.info/sct|http://snomed.info/sct/900000000000207008/version/20210731 was not found"
               },
               "diagnostics": "[29,8]",
               "expression": [
@@ -46810,23 +46742,6 @@
           "resourceType": "OperationOutcome",
           "issue": [
             {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-server",
-                  "valueUrl": "http://tx-dev.fhir.org/r4"
-                }
-              ],
-              "severity": "information",
-              "code": "business-rule",
-              "details": {
-                "text": "Reference to draft CodeSystem urn:iso:std:iso:11073:10101|2023-04-26"
-              },
-              "diagnostics": "[32,4]",
-              "expression": [
-                "Observation.code"
-              ]
-            },
-            {
               "severity": "information",
               "code": "informational",
               "details": {
@@ -48856,57 +48771,6 @@
               ]
             },
             {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-server",
-                  "valueUrl": "http://tx-dev.fhir.org/r4"
-                }
-              ],
-              "severity": "information",
-              "code": "business-rule",
-              "details": {
-                "text": "Reference to draft CodeSystem urn:iso:std:iso:11073:10101|2023-04-26"
-              },
-              "diagnostics": "[46,4]",
-              "expression": [
-                "Observation.code"
-              ]
-            },
-            {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-server",
-                  "valueUrl": "http://tx-dev.fhir.org/r4"
-                }
-              ],
-              "severity": "information",
-              "code": "business-rule",
-              "details": {
-                "text": "Reference to draft CodeSystem urn:iso:std:iso:11073:10101|2023-04-26"
-              },
-              "diagnostics": "[79,8]",
-              "expression": [
-                "Observation.component[0].code"
-              ]
-            },
-            {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-server",
-                  "valueUrl": "http://tx-dev.fhir.org/r4"
-                }
-              ],
-              "severity": "information",
-              "code": "business-rule",
-              "details": {
-                "text": "Reference to draft CodeSystem urn:iso:std:iso:11073:10101|2023-04-26"
-              },
-              "diagnostics": "[88,8]",
-              "expression": [
-                "Observation.component[0].value.ofType(CodeableConcept)"
-              ]
-            },
-            {
               "severity": "information",
               "code": "informational",
               "details": {
@@ -49006,57 +48870,6 @@
               "diagnostics": "[37,6]",
               "expression": [
                 "Observation.category[1]"
-              ]
-            },
-            {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-server",
-                  "valueUrl": "http://tx-dev.fhir.org/r4"
-                }
-              ],
-              "severity": "information",
-              "code": "business-rule",
-              "details": {
-                "text": "Reference to draft CodeSystem urn:iso:std:iso:11073:10101|2023-04-26"
-              },
-              "diagnostics": "[46,4]",
-              "expression": [
-                "Observation.code"
-              ]
-            },
-            {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-server",
-                  "valueUrl": "http://tx-dev.fhir.org/r4"
-                }
-              ],
-              "severity": "information",
-              "code": "business-rule",
-              "details": {
-                "text": "Reference to draft CodeSystem urn:iso:std:iso:11073:10101|2023-04-26"
-              },
-              "diagnostics": "[79,8]",
-              "expression": [
-                "Observation.component[0].code"
-              ]
-            },
-            {
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-server",
-                  "valueUrl": "http://tx-dev.fhir.org/r4"
-                }
-              ],
-              "severity": "information",
-              "code": "business-rule",
-              "details": {
-                "text": "Reference to draft CodeSystem urn:iso:std:iso:11073:10101|2023-04-26"
-              },
-              "diagnostics": "[88,8]",
-              "expression": [
-                "Observation.component[0].value.ofType(CodeableConcept)"
               ]
             },
             {
@@ -49563,7 +49376,7 @@
               "severity": "warning",
               "code": "code-invalid",
               "details": {
-                "text": "The Coding provided (urn:oid:1.2.840.114350.1.72.1.7.7.10.696784.13260#1) was not found in the value set 'ActEncounterCode' (http://terminology.hl7.org/ValueSet/v3-ActEncounterCode|2.0.0), and a code should come from this value set unless it has no suitable code (note that the validator cannot judge what is suitable).  (error message = Error from http://tx-dev.fhir.org/r4: Element name mismatch (start: \"tr\"/ end: \"td\") at Line 168, Column 86)"
+                "text": "The code provided (urn:oid:1.2.840.114350.1.72.1.7.7.10.696784.13260#1) is not in the value set 'ActEncounterCode' (http://terminology.hl7.org/ValueSet/v3-ActEncounterCode|2.0.0), and a code should come from this value set unless it has no suitable code (the validator cannot judge what is suitable)"
               },
               "diagnostics": "[3,319]",
               "expression": [

--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -2950,7 +2950,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'General Practice' for http://nucc.org/provider-taxonomy#208D00000X. Valid display is 'General Practice Physician' (for the language(s) '--')"
+                "text": "Wrong Display Name 'General Practice' for http://nucc.org/provider-taxonomy#208D00000X. Valid display is 'General Practice Physician' (for the language(s) 'en-US')"
               },
               "diagnostics": "[17,6]",
               "expression": [
@@ -2967,7 +2967,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'General Practice' for http://nucc.org/provider-taxonomy#208D00000X. Valid display is 'General Practice Physician' (for the language(s) '--')"
+                "text": "Wrong Display Name 'General Practice' for http://nucc.org/provider-taxonomy#208D00000X. Valid display is 'General Practice Physician' (for the language(s) 'en-US')"
               },
               "diagnostics": "[29,6]",
               "expression": [
@@ -10171,7 +10171,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Allergies and adverse reactions' for http://loinc.org#48765-2. Valid display is one of 28 choices: 'Allergies and adverse reactions Document', 'Allergies &or adverse reactions Doc' (en-US), '临床文档型' (zh-CN), '临床文档' (zh-CN), '文档' (zh-CN), '文书' (zh-CN), '医疗文书' (zh-CN), '临床医疗文书 医疗服务对象' (zh-CN), '客户' (zh-CN), '病人' (zh-CN), '病患' (zh-CN), '病号' (zh-CN), '超系统 - 病人 发现是一个原子型临床观察指标，并不是作为印象的概括陈述。体格检查、病史、系统检查及其他此类观察指标的属性均为发现。它们的标尺对于编码型发现可能是名义型，而对于叙述型文本之中所报告的发现，则可能是叙述型。' (zh-CN), '发现物' (zh-CN), '所见' (zh-CN), '结果' (zh-CN), '结论 变态反应与不良反应 文档.其他' (zh-CN), '杂项类文档' (zh-CN), '其他文档 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 杂项' (zh-CN), '杂项类' (zh-CN), '杂项试验 过敏反应' (zh-CN), '过敏' (zh-CN), 'Allergie e reazioni avverse Documentazione miscellanea Miscellanea Osservazione paziente Punto nel tempo (episodio)' (it-IT), 'Документ Точка во времени' (ru-RU) or 'Момент' (ru-RU) (for the language(s) '--')"
+                "text": "Wrong Display Name 'Allergies and adverse reactions' for http://loinc.org#48765-2. Valid display is 'Allergies and adverse reactions Document' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[26,11]",
               "expression": [
@@ -10210,7 +10210,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Allergies and adverse reactions' for http://loinc.org#48765-2. Valid display is 'Allergies and adverse reactions Document' (en-US) (for the language(s) 'en-US')"
+                "text": "Wrong Display Name 'Allergies and adverse reactions' for http://loinc.org#48765-2. Valid display is 'Allergies and adverse reactions Document' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[26,11]",
               "expression": [
@@ -10344,7 +10344,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Allergies and adverse reactions' for http://loinc.org#48765-2. Valid display is one of 28 choices: 'Allergies and adverse reactions Document', 'Allergies &or adverse reactions Doc' (en-US), '临床文档型' (zh-CN), '临床文档' (zh-CN), '文档' (zh-CN), '文书' (zh-CN), '医疗文书' (zh-CN), '临床医疗文书 医疗服务对象' (zh-CN), '客户' (zh-CN), '病人' (zh-CN), '病患' (zh-CN), '病号' (zh-CN), '超系统 - 病人 发现是一个原子型临床观察指标，并不是作为印象的概括陈述。体格检查、病史、系统检查及其他此类观察指标的属性均为发现。它们的标尺对于编码型发现可能是名义型，而对于叙述型文本之中所报告的发现，则可能是叙述型。' (zh-CN), '发现物' (zh-CN), '所见' (zh-CN), '结果' (zh-CN), '结论 变态反应与不良反应 文档.其他' (zh-CN), '杂项类文档' (zh-CN), '其他文档 时刻' (zh-CN), '随机' (zh-CN), '随意' (zh-CN), '瞬间 杂项' (zh-CN), '杂项类' (zh-CN), '杂项试验 过敏反应' (zh-CN), '过敏' (zh-CN), 'Allergie e reazioni avverse Documentazione miscellanea Miscellanea Osservazione paziente Punto nel tempo (episodio)' (it-IT), 'Документ Точка во времени' (ru-RU) or 'Момент' (ru-RU) (for the language(s) '--')"
+                "text": "Wrong Display Name 'Allergies and adverse reactions' for http://loinc.org#48765-2. Valid display is 'Allergies and adverse reactions Document' (en-US) (for the language(s) 'en-US')"
               },
               "diagnostics": "[26,11]",
               "expression": [
@@ -17842,7 +17842,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'COVID-19' for http://snomed.info/sct#840535000. Valid display is one of 7 choices: 'Antibody to 2019 novel coronavirus', 'Antibody to 2019-nCoV', 'Antibody to severe acute respiratory syndrome coronavirus 2 (substance)', 'Antibody to severe acute respiratory syndrome coronavirus 2', 'Antibody to SARS-CoV-2', 'Severe acute respiratory syndrome coronavirus 2 Ab' or 'Severe acute respiratory syndrome coronavirus 2 antibody' (for the language(s) '--')"
+                "text": "Wrong Display Name 'COVID-19' for http://snomed.info/sct#840535000. Valid display is one of 7 choices: 'Antibody to 2019 novel coronavirus', 'Antibody to 2019-nCoV', 'Antibody to severe acute respiratory syndrome coronavirus 2 (substance)', 'Antibody to severe acute respiratory syndrome coronavirus 2', 'Antibody to SARS-CoV-2', 'Severe acute respiratory syndrome coronavirus 2 Ab' or 'Severe acute respiratory syndrome coronavirus 2 antibody' (for the language(s) 'en-US')"
               },
               "diagnostics": "[42,8]",
               "expression": [
@@ -17956,7 +17956,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'COVID-19' for http://snomed.info/sct#840535000. Valid display is one of 7 choices: 'Antibody to 2019 novel coronavirus', 'Antibody to 2019-nCoV', 'Antibody to severe acute respiratory syndrome coronavirus 2 (substance)', 'Antibody to severe acute respiratory syndrome coronavirus 2', 'Antibody to SARS-CoV-2', 'Severe acute respiratory syndrome coronavirus 2 Ab' or 'Severe acute respiratory syndrome coronavirus 2 antibody' (for the language(s) '--')"
+                "text": "Wrong Display Name 'COVID-19' for http://snomed.info/sct#840535000. Valid display is one of 7 choices: 'Antibody to 2019 novel coronavirus', 'Antibody to 2019-nCoV', 'Antibody to severe acute respiratory syndrome coronavirus 2 (substance)', 'Antibody to severe acute respiratory syndrome coronavirus 2', 'Antibody to SARS-CoV-2', 'Severe acute respiratory syndrome coronavirus 2 Ab' or 'Severe acute respiratory syndrome coronavirus 2 antibody' (for the language(s) 'en-US')"
               },
               "diagnostics": "[42,8]",
               "expression": [
@@ -18176,7 +18176,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'COVID-19' for http://snomed.info/sct#840535000. Valid display is one of 7 choices: 'Antibody to 2019 novel coronavirus', 'Antibody to 2019-nCoV', 'Antibody to severe acute respiratory syndrome coronavirus 2 (substance)', 'Antibody to severe acute respiratory syndrome coronavirus 2', 'Antibody to SARS-CoV-2', 'Severe acute respiratory syndrome coronavirus 2 Ab' or 'Severe acute respiratory syndrome coronavirus 2 antibody' (for the language(s) '--')"
+                "text": "Wrong Display Name 'COVID-19' for http://snomed.info/sct#840535000. Valid display is one of 7 choices: 'Antibody to 2019 novel coronavirus', 'Antibody to 2019-nCoV', 'Antibody to severe acute respiratory syndrome coronavirus 2 (substance)', 'Antibody to severe acute respiratory syndrome coronavirus 2', 'Antibody to SARS-CoV-2', 'Severe acute respiratory syndrome coronavirus 2 Ab' or 'Severe acute respiratory syndrome coronavirus 2 antibody' (for the language(s) 'en-US')"
               },
               "diagnostics": "[26,8]",
               "expression": [
@@ -30897,7 +30897,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Malignant neoplasm of pyriform sinus' for http://hl7.org/fhir/sid/icd-10#C12. Valid display is 'Malignant neoplasm of piriform sinus' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Malignant neoplasm of pyriform sinus' for http://hl7.org/fhir/sid/icd-10#C12. Valid display is 'Malignant neoplasm of piriform sinus' (for the language(s) 'en-US')"
               },
               "diagnostics": "[126,4]",
               "expression": [
@@ -33915,7 +33915,7 @@
               "severity": "error",
               "code": "invalid",
               "details": {
-                "text": "Wrong Display Name 'Diagnostisk med biopsi' for http://snomed.info/sct#446745002. Valid display is one of 2 choices: 'Colonoscopy and biopsy of colon (procedure)' or 'Colonoscopy and biopsy of colon' (for the language(s) '--')"
+                "text": "Wrong Display Name 'Diagnostisk med biopsi' for http://snomed.info/sct#446745002. Valid display is one of 2 choices: 'Colonoscopy and biopsy of colon (procedure)' or 'Colonoscopy and biopsy of colon' (for the language(s) 'en-US')"
               },
               "diagnostics": "[152,18]",
               "expression": [


### PR DESCRIPTION
Code validation should now use en-US as the default language when no other language is specified by the resource. 