### PR TITLE
add reference-slice-resolve test

### DIFF
--- a/validator/Observation-TestObservationInstanceWithResolve.json
+++ b/validator/Observation-TestObservationInstanceWithResolve.json
@@ -1,0 +1,23 @@
+{
+  "resourceType": "Observation",
+  "id": "TestObservationInstanceWithResolve",
+  "meta": {
+    "profile": [
+      "http://example.org/StructureDefinition/TestObservationProfileWithResolve"
+    ]
+  },
+  "performer": [
+    {
+      "reference": "Patient/pat-good"
+    }
+  ],
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "code": "test",
+        "system": "http://test.org/CodeSystem"
+      }
+    ]
+  }
+}

--- a/validator/StructureDefinition-TestObservationProfileWithResolve.json
+++ b/validator/StructureDefinition-TestObservationProfileWithResolve.json
@@ -1,0 +1,48 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "TestObservationProfileWithResolve",
+  "url": "http://example.org/StructureDefinition/TestObservationProfileWithResolve",
+  "name": "TestObservationProfileWithResolve",
+  "title": "TestObservationProfileWithResolve",
+  "status": "draft",
+  "description": "TestObservationProfileWithResolve",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Observation",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Observation.performer",
+        "path": "Observation.performer",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "type",
+              "path": "$this.resolve()"
+            }
+          ],
+          "rules": "open"
+        },
+        "min": 1
+      },
+      {
+        "id": "Observation.performer:test",
+        "path": "Observation.performer",
+        "sliceName": "test",
+        "min": 1,
+        "max": "1",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Patient"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -50179,6 +50179,36 @@
       }
     },
     {
+      "name": "reference-slice-resolve",
+      "file": "Observation-TestObservationInstanceWithResolve.json",
+      "version": "4.0",
+      "description": "Validator should be able to fetch reference from validation context",
+      "supporting": [
+        "StructureDefinition-TestObservationProfileWithResolve.json",
+        "patient-good.json"
+      ],
+      "java": {
+        "warningCount": 1,
+        "outcome": {
+          "resource": {
+            "resourceType": "OperationOutcome",
+            "issue": [
+              {
+                "severity": "warning",
+                "code": "not-found",
+                "details": {
+                  "text": "A definition for CodeSystem 'http://test.org/CodeSystem' could not be found, so the code cannot be validated"
+                },
+                "expression": [
+                  "Observation.code.coding[0].system"
+                ]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
       "name": "zzz",
       "file": "zzz.json",
       "description": "hack to close ups",


### PR DESCRIPTION
This testcase has a Observation profile with a sliced performer (by type, resolve()), the java validator fails to resolve the referenced patient and reports an error.

Related PR trying to fix this issue: https://github.com/hapifhir/org.hl7.fhir.core/pull/1834

Zulip discussion:
https://chat.fhir.org/#narrow/channel/179166-implementers/topic/Validation.20error.20on.20type.20slicing.20with.20resolve.28.29