### PR TITLE
Add test for wrong display errors with new advisor and instance files

### DIFF
--- a/validator/filter-invalid-display-advisor.json
+++ b/validator/filter-invalid-display-advisor.json
@@ -1,0 +1,6 @@
+{
+  "suppress": [
+    "Display_Name_for__should_be_one_of__instead_of@DocumentReference.content[0].format.display",
+    "Terminology_TX_Confirm_6@DocumentReference.content[0].format"
+  ]
+}

--- a/validator/filter-invalid-display-instance.json
+++ b/validator/filter-invalid-display-instance.json
@@ -1,0 +1,18 @@
+{
+  "resourceType": "DocumentReference",
+  "id": "MinimalWrongDisplayTest",
+  "status": "current",
+  "content": [
+    {
+      "format": {
+        "code": "urn:ihe:iti:xds:2017:mimeTypeSufficient",
+        "system": "http://ihe.net/fhir/ihe.formatcode.fhir/CodeSystem/formatcode",
+        "display": "Format aus MIME Type ableitbar"
+      },
+      "attachment": {
+        "title": "Test",
+        "url": "http://example.com/test.pdf"
+      }
+    }
+  ]
+}

--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -11318,6 +11318,17 @@
       "file": "zzz.json",
       "description": "hack for close ups",
       "close-up": true
+    },
+    {
+      "name": "filter-invalid-display",
+      "file": "filter-invalid-display-instance.json",
+      "description": "Check that the wrong display error can be filtered in the advisor file",
+      "version": "4.0",
+      "module": "profile",
+      "advisor" : "filter-invalid-display-advisor.json",
+      "java": {
+        "errorCount": 0
+      }
     }
   ]
 }


### PR DESCRIPTION
this ist a test for https://github.com/hapifhir/org.hl7.fhir.core/issues/2063 and tests if a wrong display error can be filtered by its messageId: `Display_Name_for__should_be_one_of__instead_of`

