### PR TITLE
added testcase for pattern on cc.coding.system only

### DIFF
--- a/validator/cc-pattern-system-only-cs.json
+++ b/validator/cc-pattern-system-only-cs.json
@@ -1,0 +1,20 @@
+{
+  "resourceType": "CodeSystem",
+  "status": "active",
+  "content": "complete",
+  "name": "TestCodeSystem",
+  "id": "TestCodeSystem",
+  "title": "TestCodeSystem",
+  "url": "https://gematik.de/fhir/isik/CodeSystem/TestCodeSystem",
+  "concept": [
+    {
+      "code": "1",
+      "display": "first"
+    },
+    {
+      "code": "2",
+      "display": "second"
+    }
+  ],
+  "count": 2
+}

--- a/validator/cc-pattern-system-only-profile.json
+++ b/validator/cc-pattern-system-only-profile.json
@@ -1,0 +1,28 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "TestEncounterProfile",
+  "url": "https://gematik.de/fhir/isik/StructureDefinition/TestEncounterProfile",
+  "name": "TestEncounterProfile",
+  "status": "draft",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Encounter",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Encounter",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Encounter.type",
+        "path": "Encounter.type",
+        "patternCodeableConcept": {
+          "coding": [
+            {
+              "system": "https://gematik.de/fhir/isik/CodeSystem/TestCodeSystem"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -11436,6 +11436,19 @@
       "file": "zzz.json",
       "description": "hack for close ups",
       "close-up": true
+    },
+    {
+      "name": "cc-pattern-system-only",
+      "file": "cc-pattern-system-only-profile.json",
+      "description": "Profile that has a pattern on cc.coding.system with system only is valid",
+      "version": "4.0",
+      "module": "profile",
+      "supporting": [
+        "cc-pattern-system-only-cs.json"
+      ],
+      "java": {
+        "errorCount": 0
+      }
     }
   ]
 }


### PR DESCRIPTION
When using a patternCodeableConcept constraint on the coding.system element, pointing to a CodeSystem via its canonical URL, the Java FHIR Validator reports an “Unknown code ‘’” error—even though the CodeSystem is correctly defined and contains valid codes.

This pull request introduces new resources and updates to the `validator` module, primarily focusing on adding a test code system and a corresponding profile, as well as updating the manifest to include these resources. Below is a breakdown of the most important changes:

### Addition of new resources:

* [`validator/cc-pattern-system-only-cs.json`](diffhunk://#diff-ed98bf61da8daf671622e71a7e9c2eac387fab6c33b1a78418fa608da2120063R1-R20): Added a new CodeSystem resource named `TestCodeSystem` with two concepts (`code: 1` and `code: 2`) and metadata such as `id`, `url`, and `status`.
* [`validator/cc-pattern-system-only-profile.json`](diffhunk://#diff-a952c12402cc9c941541af806774dabafaf274722e1f5b48d807c45e76aafd06R1-R28): Added a new StructureDefinition resource named `TestEncounterProfile`, which constrains the `Encounter.type` element to use a specific pattern referencing the newly added `TestCodeSystem`.

### Manifest update:

* [`validator/manifest.json`](diffhunk://#diff-d4b779183257c788496027732b22fa637c80779565b82c96da882de36e9f5ab9R11439-R11451): Updated the manifest to include the new profile (`cc-pattern-system-only-profile.json`) and its supporting CodeSystem (`cc-pattern-system-only-cs.json`). Metadata such as `description`, `version`, and `module` were added for the new entry.