### PR TITLE
Add filter display error test for wrong display

### DIFF
--- a/validator/filter-display-error-with-path-advisor.json
+++ b/validator/filter-display-error-with-path-advisor.json
@@ -1,0 +1,8 @@
+{
+  "suppress": [
+    "NO_VALID_DISPLAY_FOUND_NONE_FOR_LANG_ERR@Observation.code.coding[0].display",
+    "http://hl7.org/fhir/StructureDefinition/DomainResource#dom-6",
+    "All_observations_should_have_a_performer",
+    "All_observations_should_have_an_effectiveDateTime_or_an_effectivePeriod"
+  ]
+}

--- a/validator/filter-display-error-with-path-observation.json
+++ b/validator/filter-display-error-with-path-observation.json
@@ -1,0 +1,17 @@
+{
+  "resourceType": "Observation",
+  "id": "ExampleCRP1",
+  "subject": {
+    "reference": "Patient/PatientinMusterfrau"
+  },
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "code": "1988-5",
+        "system": "http://loinc.org",
+        "display": "C-reaktives Protein [Masse/Volumen] in Serum oder Plasma"
+      }
+    ]
+  }
+}

--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -11436,6 +11436,17 @@
       "file": "zzz.json",
       "description": "hack for close ups",
       "close-up": true
+    },
+    {
+      "name": "filter-display-error-with-path",
+      "file": "filter-display-error-with-path-observation.json",
+      "description": "Test to filter a wrong display error with a path",
+      "version": "4.0",
+      "module": "profile",
+      "advisor" : "filter-display-error-with-path-advisor.json",
+      "java": {
+        "errorCount": 0
+      }
     }
   ]
 }


### PR DESCRIPTION
When using the advisor file for  NO_VALID_DISPLAY_FOUND_NONE_FOR_LANG_ERR **with** a path, filtering doesn't work.
This PR adds a test-case showing the issue

@Observation.code.coding[0].display

This pull request introduces new resources and configurations to filter display errors in FHIR validation tests. The changes primarily focus on adding a test case to handle display errors with specific paths and suppressing related validation errors.

### Additions for filtering display errors:

* [`validator/filter-display-error-with-path-advisor.json`](diffhunk://#diff-c9a5a124d54bf4b5e2375f1f257dd9690493eec7af32827eb1bf65b1be5c4658R1-R8): Added a configuration file to suppress specific validation errors related to observation coding displays and required fields for observations.
* [`validator/filter-display-error-with-path-observation.json`](diffhunk://#diff-0b103633e64088c27122bf3eab0e4cebd3dac1a64678ae5d3abe9b610ef8b8a6R1-R17): Added a new resource example (`Observation`) with coding details to test the filtering of display errors.

### Updates to test manifest:

* [`validator/manifest.json`](diffhunk://#diff-d4b779183257c788496027732b22fa637c80779565b82c96da882de36e9f5ab9R11439-R11449): Added a new test case entry (`filter-display-error-with-path`) to the manifest, specifying the resource file, advisor file, and metadata such as version, module, and expected error count.