### PR TITLE
Add questionnaire decimal places validation tests

### DIFF
--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -11567,6 +11567,17 @@
       "file": "zzz.json",
       "description": "hack for close ups",
       "close-up": true
+    },
+    {
+      "name": "decimal-precision-questionnaire",
+      "file": "questionnaire/QuestionnaireResponse-ExampleEntryValidationDecimalResponse.json",
+      "description": "Verify ExampleEntryValidationDecimalResponse against ExampleEntryValidationDecimal, testing maxDecimalPlaces constraint, expecting success: True",
+      "version": "4.0",
+      "supporting": [
+        "questionnaire/Questionnaire-ExampleEntryValidationDecimal.json"
+      ],
+      "module": "questionnaire",
+      "java": "java/decimal-precision-questionnaire-outcome.json"
     }
   ]
 } 

--- a/validator/outcomes/java/decimal-precision-questionnaire-outcome.json
+++ b/validator/outcomes/java/decimal-precision-questionnaire-outcome.json
@@ -1,0 +1,35 @@
+{
+  "resourceType" : "OperationOutcome",
+  "text" : {
+    "status" : "generated",
+    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>OperationOutcome </b></p><table class=\"grid\"><tr><td><b>Severity</b></td><td><b>Location</b></td><td><b>Code</b></td><td><b>Details</b></td><td><b>Diagnostics</b></td><td><b>Source</b></td></tr><tr><td>Warning</td><td>QuestionnaireResponse</td><td>Validation rule failed</td><td>Constraint failed: dom-6: 'A resource should have narrative for robust management' (defined in http://hl7.org/fhir/StructureDefinition/DomainResource) (Best Practice Recommendation)</td><td/><td>InstanceValidator</td></tr></table></div>"
+  },
+  "extension" : [{
+    "url" : "http://hl7.org/fhir/StructureDefinition/operationoutcome-file",
+    "valueString" : "/Users/patrickwerner/Downloads/QuestionnaireResponse-ExampleEntryValidationDecimalResponse.json"
+  }],
+  "issue" : [{
+    "extension" : [{
+      "url" : "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-line",
+      "valueInteger" : 1
+    },
+      {
+        "url" : "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-col",
+        "valueInteger" : 2
+      },
+      {
+        "url" : "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-source",
+        "valueString" : "InstanceValidator"
+      },
+      {
+        "url" : "http://hl7.org/fhir/StructureDefinition/operationoutcome-message-id",
+        "valueCode" : "http://hl7.org/fhir/StructureDefinition/DomainResource#dom-6"
+      }],
+    "severity" : "warning",
+    "code" : "invariant",
+    "details" : {
+      "text" : "Constraint failed: dom-6: 'A resource should have narrative for robust management' (defined in http://hl7.org/fhir/StructureDefinition/DomainResource) (Best Practice Recommendation)"
+    },
+    "expression" : ["QuestionnaireResponse"]
+  }]
+}

--- a/validator/questionnaire/Questionnaire-ExampleEntryValidationDecimal.json
+++ b/validator/questionnaire/Questionnaire-ExampleEntryValidationDecimal.json
@@ -1,0 +1,43 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "ExampleEntryValidationDecimal",
+  "name": "ExampleEntryValidationDecimal",
+  "version": "0.1.0",
+  "url": "https://gematik.de/fhir/isik/Questionnaire/ExampleEntryValidationDecimal",
+  "status": "active",
+  "experimental": false,
+  "title": "Validierung von Dezimalen",
+  "description": "### Beispiel-Questionnaire Validierung von Dezimalwerten  \r\n* Vorgabe des Eingabeformates mittels [entryFormat](https://hl7.org/fhir/R4/extension-entryformat.html)-Extension\r\n* Limitierung der Dezimalstellen mittels [maxDecimalPlaces](https://hl7.org/fhir/extension-maxdecimalplaces.html)-Extension\r\n* Limitierung des Wertebereiches mittels [minValue](https://hl7.org/fhir/extension-minvalue.html) \r\n   und [maxValue](https://hl7.org/fhir/extension-maxvalue.html)-Extension\r\n* Vorgabe der anzugebenden Maßeinheit mittels [questionnaire-unit](https://hl7.org/fhir/R4/extension-questionnaire-unit.html)-Extension",
+  "item": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/maxDecimalPlaces",
+          "valueInteger": 2
+        }
+      ],
+      "linkId": "testId1",
+      "text": "Körpergröße in m (muss zwischen 1m und 2.50m liegen)",
+      "type": "decimal"
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/maxDecimalPlaces",
+          "valueInteger": 2
+        },
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+          "valueCoding": {
+            "system": "http://unitsofmeasure.org",
+            "code": "kg",
+            "display": "Kilogramm"
+          }
+        }
+      ],
+      "linkId": "testId2",
+      "text": "Körpergewicht in kg (muss zwischen 40kg und 200kg liegen)",
+      "type": "quantity"
+    }
+  ]
+}

--- a/validator/questionnaire/QuestionnaireResponse-ExampleEntryValidationDecimalResponse.json
+++ b/validator/questionnaire/QuestionnaireResponse-ExampleEntryValidationDecimalResponse.json
@@ -1,0 +1,38 @@
+{
+  "resourceType": "QuestionnaireResponse",
+  "id": "ExampleEntryValidationDecimalResponse",
+  "questionnaire": "https://gematik.de/fhir/isik/Questionnaire/ExampleEntryValidationDecimal",
+  "status": "completed",
+  "subject": {
+    "reference": "Patient/PatientinMinimal"
+  },
+  "author": {
+    "reference": "Patient/PatientinMinimal"
+  },
+  "authored": "2025-01-01",
+  "item": [
+    {
+      "linkId": "testId1",
+      "text": "Körpergröße in m (muss zwischen 1m und 2.50m liegen)",
+      "answer": [
+        {
+          "valueDecimal": 1.66
+        }
+      ]
+    },
+    {
+      "linkId": "testId2",
+      "text": "Körpergewicht in kg (muss zwischen 40kg und 200kg liegen)",
+      "answer": [
+        {
+          "valueQuantity": {
+            "value": 72.52,
+            "unit": "kg",
+            "system": "http://unitsofmeasure.org",
+            "code": "kg"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds a new test case to validate decimal precision constraints in FHIR Questionnaire resources, specifically verifying the enforcement of the `maxDecimalPlaces` extension. The update includes a new `Questionnaire`, a corresponding `QuestionnaireResponse`, and the expected Java validation outcome, along with the necessary manifest and outcome files.

**New decimal precision validation test:**

* Test configuration:
  - Added a new entry `decimal-precision-questionnaire` to `validator/manifest.json` to define the test case, referencing the relevant files and expected outcome.

* Test resources:
  - Added `Questionnaire-ExampleEntryValidationDecimal.json`, which defines decimal and quantity items with a `maxDecimalPlaces` constraint and unit specification.
  - Added `QuestionnaireResponse-ExampleEntryValidationDecimalResponse.json`, providing valid responses to the questionnaire, respecting the decimal precision constraints.

* Expected validation outcome:
  - Added `java/decimal-precision-questionnaire-outcome.json`, specifying the expected OperationOutcome, including a warning about missing narrative text (dom-6 best practice recommendation).