### PR TITLE
Add test case for sdc-questionnaire-minQuantity with identical system and code

### DIFF
--- a/r5/questionnaire-example-f201-lifelines.xml
+++ b/r5/questionnaire-example-f201-lifelines.xml
@@ -53,6 +53,28 @@
       <text value="What is your marital status?"/>
       <type value="string"/>
     </item>
+    <item>
+      <extension url="http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-minQuantity">
+        <valueQuantity>
+          <value value="0"/>
+          <unit value="kg"/>
+          <system value="http://unitsofmeasure.org"/>
+          <code value="kg"/>
+        </valueQuantity>
+      </extension>
+      <extension url="http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-maxQuantity">
+        <valueQuantity>
+          <value value="500"/>
+          <unit value="kg"/>
+          <system value="http://unitsofmeasure.org"/>
+          <code value="kg"/>
+        </valueQuantity>
+      </extension>
+      <linkId value="2.5"/>
+      <text value="What is your current weight in kilograms?"/>
+      <type value="quantity"/>
+      <required value="true"/>
+    </item>
   </item>
   <item>
     <linkId value="3"/>

--- a/r5/questionnaireresponse-example-f201-lifelines.xml
+++ b/r5/questionnaireresponse-example-f201-lifelines.xml
@@ -56,6 +56,18 @@
         <valueString value="married"/>
       </answer>
     </item>
+    <item>
+      <linkId value="2.5"/>
+      <text value="What is your current weight in kilograms?"/>
+      <answer>
+        <valueQuantity>
+          <value value="87"/>
+          <unit value="kg"/>
+          <system value="http://unitsofmeasure.org"/>
+          <code value="kg"/>
+        </valueQuantity>
+      </answer>
+    </item>
   </item>
   <item>
     <!--  Answers to intoxications  -->


### PR DESCRIPTION
Provides test cases for the inverted minQuantity comparison logic reported in
hapifhir/org.hl7.fhir.core#2374 and fixed in hapifhir/org.hl7.fhir.core#<PR-Nummer>.

Extends the existing quantity questionnaire with a patient weight item (kg) that
carries both sdc-questionnaire-minQuantity and sdc-questionnaire-maxQuantity
constraints using identical system and code — the exact scenario where the
comparison logic was inverted.