### PR TITLE
Add test case: preferred binding on Address.country must produce WARNING, not ERROR

### DIFF
--- a/validator/address-country-preferred-binding-profile.xml
+++ b/validator/address-country-preferred-binding-profile.xml
@@ -1,0 +1,28 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="address-country-preferred-binding" />
+  <url value="http://example.org/fhir/StructureDefinition/address-country-preferred-binding" />
+  <version value="1.0.0" />
+  <name value="AddressCountryPreferredBinding" />
+  <title value="Address with preferred binding on country" />
+  <status value="active" />
+  <description value="Minimal Address profile that adds a preferred binding to Address.country pointing to the ISO 3166-1-2 ValueSet. Validates that a non-ISO country code (e.g. the Destatis code '20422' for Germany) produces a WARNING, not an ERROR, because the binding strength is 'preferred'." />
+  <fhirVersion value="4.0.1" />
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <type value="Address" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Address" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Address.country">
+      <path value="Address.country" />
+      <short value="Staat" />
+      <definition value="Staat (vorzugsweise als 2-Stelliger ISO-Ländercode).&#xD;&#xA;Es obliegt abgeleiteten Profilen, hier die Verwendung der ISO-Ländercodes verbindlich vorzuschreiben" />
+      <comment value="ISO 3166 3 letter codes can be used in place of a human readable country name." />
+      <binding>
+        <strength value="preferred" />
+        <valueSet value="http://hl7.org/fhir/ValueSet/iso3166-1-2" />
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>
+

--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -8172,6 +8172,21 @@
       "java": "java/R4.de-address-example-base.json"
     },
     {
+      "name": "patient-country-noniso-bad",
+      "file": "patient-country-noniso-bad.xml",
+      "version": "4.0",
+      "explanation": "Patient with Address.country='20422' (Destatis key for Germany, not an ISO 3166-1-2 code). The address profile defines a PREFERRED binding to http://hl7.org/fhir/ValueSet/iso3166-1-2. Per HL7 FHIR spec (https://hl7.org/fhir/R4/terminologies.html#preferred) a preferred binding MUST produce severity WARNING, never ERROR. Some validator implementations incorrectly produce ERROR here.",
+      "profile": {
+        "source": "patient-address-preferred-country-profile.xml",
+        "supporting": [
+          "address-country-preferred-binding-profile.xml"
+        ],
+        "java": "java/R4.patient-country-noniso-profile.json"
+      },
+      "module": "profile",
+      "java": "java/R4.patient-country-noniso-base.json"
+    },
+    {
       "name": "qr-internal-refs",
       "file": "qr-internal-refs.json",
       "version": "4.0",

--- a/validator/outcomes/java/R4.patient-country-noniso-base.json
+++ b/validator/outcomes/java/R4.patient-country-noniso-base.json
@@ -1,0 +1,16 @@
+{
+  "resourceType" : "OperationOutcome",
+  "issue" : [{
+    "extension" : [{
+      "url" : "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-context",
+      "valueString" : "http://hl7.org/fhir/StructureDefinition/Patient|4.0.1"
+    }],
+    "severity" : "warning",
+    "code" : "code-invalid",
+    "details" : {
+      "text" : "The value '20422' is not in the value set 'Iso 3166 Part 1: 2 Letter Codes' (http://hl7.org/fhir/ValueSet/iso3166-1-2|4.0.1), and a code should come from this value set unless it has no suitable code (note that the validator cannot judge what is suitable)"
+    },
+    "expression" : ["Patient.address[0].country"]
+  }]
+}
+

--- a/validator/outcomes/java/R4.patient-country-noniso-profile.json
+++ b/validator/outcomes/java/R4.patient-country-noniso-profile.json
@@ -1,0 +1,16 @@
+{
+  "resourceType" : "OperationOutcome",
+  "issue" : [{
+    "extension" : [{
+      "url" : "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-context",
+      "valueString" : "http://example.org/fhir/StructureDefinition/patient-address-preferred-country"
+    }],
+    "severity" : "warning",
+    "code" : "code-invalid",
+    "details" : {
+      "text" : "The value '20422' is not in the value set 'Iso 3166 Part 1: 2 Letter Codes' (http://hl7.org/fhir/ValueSet/iso3166-1-2|4.0.1), and a code should come from this value set unless it has no suitable code (note that the validator cannot judge what is suitable)"
+    },
+    "expression" : ["Patient.address[0].country"]
+  }]
+}
+

--- a/validator/patient-address-preferred-country-profile.xml
+++ b/validator/patient-address-preferred-country-profile.xml
@@ -1,0 +1,25 @@
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="patient-address-preferred-country" />
+  <url value="http://example.org/fhir/StructureDefinition/patient-address-preferred-country" />
+  <version value="1.0.0" />
+  <name value="PatientAddressPreferredCountry" />
+  <title value="Patient with preferred ISO-country binding on address" />
+  <status value="active" />
+  <description value="Patient profile that constrains Patient.address to use the AddressCountryPreferredBinding profile. Used to demonstrate that validators incorrectly produce ERROR (instead of WARNING) for a preferred binding violation on Address.country." />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Patient" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Patient" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Patient.address">
+      <path value="Patient.address" />
+      <type>
+        <code value="Address" />
+        <profile value="http://example.org/fhir/StructureDefinition/address-country-preferred-binding" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>
+

--- a/validator/patient-country-noniso-bad.xml
+++ b/validator/patient-country-noniso-bad.xml
@@ -1,0 +1,30 @@
+<Patient xmlns="http://hl7.org/fhir">
+  <id value="patient-country-noniso-bad" />
+  <!--
+    This patient has a country value of "20422", which is the Destatis (Statistisches Bundesamt)
+    numeric key for Germany. It is NOT a valid ISO 3166-1 alpha-2 code (which would be "DE").
+
+    The address profile applied to this resource (address-country-preferred-binding-profile.xml)
+    defines a PREFERRED binding to http://hl7.org/fhir/ValueSet/iso3166-1-2.
+
+    Expected validator behaviour (per HL7 FHIR specification):
+      - severity: WARNING  (binding strength "preferred" → validator SHALL only warn)
+
+    Observed (incorrect) behaviour in some validator implementations:
+      - severity: ERROR    (incorrectly treating "preferred" as "required")
+
+    See: https://hl7.org/fhir/R4/terminologies.html#preferred
+  -->
+  <name>
+    <family value="Mustermann" />
+    <given value="Max" />
+  </name>
+  <address>
+    <use value="home" />
+    <line value="Musterstraße 1" />
+    <city value="Musterstadt" />
+    <postalCode value="12345" />
+    <country value="20422" />
+  </address>
+</Patient>
+


### PR DESCRIPTION
### Summary

Adds a regression test case to document and enforce correct validator behaviour
for `preferred` bindings on `Address.country`.

Relates to: hapifhir/org.hl7.fhir.core#2269

---

### Problem

When a profile defines a `preferred` binding on `Address.country` pointing to
`http://hl7.org/fhir/ValueSet/iso3166-1-2`, some validator implementations
produce `severity: error` in the OperationOutcome when the instance uses a
country code that is not in the ValueSet.

This is **incorrect** per the HL7 FHIR specification:

> **preferred** – Instances are encouraged to draw from the specified codes for
> interoperability purposes but are not required to do so to be considered valid.
> ([FHIR R4 §Terminology Binding Strengths](https://hl7.org/fhir/R4/terminologies.html#preferred))

A `preferred` binding violation MUST produce `severity: warning` at most.
`severity: error` is only permissible for `required` bindings.

---

### Test case

The test uses `Address.country = "20422"`, the numeric Destatis key for Germany
used by some German health-IT systems. It is **not** a valid ISO 3166-1 alpha-2
code (which would be `DE`), so it reliably triggers the binding check.

| File | Role |
|------|------|
| `validator/address-country-preferred-binding-profile.xml` | Minimal `Address` profile with `preferred` binding on `Address.country` → `iso3166-1-2` |
| `validator/patient-address-preferred-country-profile.xml` | `Patient` profile constraining `Patient.address` to the above `Address` profile |
| `validator/patient-country-noniso-bad.xml` | Patient instance with `Address.country = "20422"` |
| `validator/outcomes/java/R4.patient-country-noniso-base.json` | Expected base-validation outcome (`severity: warning`) |
| `validator/outcomes/java/R4.patient-country-noniso-profile.json` | Expected profile-validation outcome (`severity: warning`) |

---

### Expected outcome (both base and profile validation)

```json
{
  "severity": "warning",
  "code": "code-invalid",
  "details": {
    "text": "The value '20422' is not in the value set 'Iso 3166 Part 1: 2 Letter Codes' ..."
  },
  "expression": ["Patient.address[0].country"]
}