### PR TITLE
Add validator test case: reslicing a complex extension with inline sub-extensions

### DIFF
--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -6237,6 +6237,18 @@
       "java": "java/R5.reslicing-extensions-base.json"
     },
     {
+      "name": "reslicing-inline-subextension",
+      "file": "reslicing-inline-subextension-instance.json",
+      "description": "Re-slices a complex extension whose sub-extensions are defined inline (no type.profile), discriminated by extension('function').value. A sibling slice has no 'function' sub-extension, so the added discriminator does not resolve for it - which R5 5.1.0.13 allows. See https://github.com/hapifhir/org.hl7.fhir.core/issues/2138",
+      "version": "5.0",
+      "profiles": [
+        "reslicing-inline-subextension-extension.json",
+        "reslicing-inline-subextension-profile.json"
+      ],
+      "module": "extensions",
+      "java": "java/R5.reslicing-inline-subextension-base.json"
+    },
+    {
       "name": "reslicing-good-extensions",
       "file": "reslicing-good-extensions-instance.json",
       "description": "See https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/Reslicing.20extensions.20causes.20validator.20errors",

--- a/validator/outcomes/java/R5.reslicing-inline-subextension-base.json
+++ b/validator/outcomes/java/R5.reslicing-inline-subextension-base.json
@@ -1,0 +1,3 @@
+{
+  "resourceType" : "OperationOutcome"
+}

--- a/validator/reslicing-inline-subextension-extension.json
+++ b/validator/reslicing-inline-subextension-extension.json
@@ -1,0 +1,110 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "InlineSubExtensionPerformer",
+  "url": "http://example.org/inlinesubext/StructureDefinition/performer",
+  "version": "0.1.0",
+  "name": "InlineSubExtensionPerformer",
+  "title": "Performer (complex extension with inline sub-extensions)",
+  "status": "draft",
+  "description": "A complex extension whose children are defined inline, so they carry no type.profile and are identified only by their fixed url. This mirrors how the hl7.fhir.uv.xver-r5.r4 cross-version extensions are built.",
+  "fhirVersion": "5.0.0",
+  "kind": "complex-type",
+  "abstract": false,
+  "context": [
+    {
+      "type": "element",
+      "expression": "AuditEvent.agent"
+    }
+  ],
+  "type": "Extension",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Extension",
+        "path": "Extension",
+        "min": 0,
+        "max": "*"
+      },
+      {
+        "id": "Extension.extension",
+        "path": "Extension.extension",
+        "min": 2,
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "rules": "open"
+        }
+      },
+      {
+        "id": "Extension.extension:function",
+        "path": "Extension.extension",
+        "sliceName": "function",
+        "min": 1,
+        "max": "1"
+      },
+      {
+        "id": "Extension.extension:function.extension",
+        "path": "Extension.extension.extension",
+        "max": "0"
+      },
+      {
+        "id": "Extension.extension:function.url",
+        "path": "Extension.extension.url",
+        "fixedUri": "function"
+      },
+      {
+        "id": "Extension.extension:function.value[x]",
+        "path": "Extension.extension.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "CodeableConcept"
+          }
+        ]
+      },
+      {
+        "id": "Extension.extension:actor",
+        "path": "Extension.extension",
+        "sliceName": "actor",
+        "min": 1,
+        "max": "1"
+      },
+      {
+        "id": "Extension.extension:actor.extension",
+        "path": "Extension.extension.extension",
+        "max": "0"
+      },
+      {
+        "id": "Extension.extension:actor.url",
+        "path": "Extension.extension.url",
+        "fixedUri": "actor"
+      },
+      {
+        "id": "Extension.extension:actor.value[x]",
+        "path": "Extension.extension.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "fixedUri": "http://example.org/inlinesubext/StructureDefinition/performer"
+      },
+      {
+        "id": "Extension.value[x]",
+        "path": "Extension.value[x]",
+        "max": "0"
+      }
+    ]
+  }
+}

--- a/validator/reslicing-inline-subextension-instance.json
+++ b/validator/reslicing-inline-subextension-instance.json
@@ -1,0 +1,80 @@
+{
+  "resourceType": "AuditEvent",
+  "id": "InlineSubExtensionInstance",
+  "meta": {
+    "profile": [
+      "http://example.org/inlinesubext/StructureDefinition/InlineSubExtensionAuditEventProfile"
+    ]
+  },
+  "agent": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/auditevent-AlternativeUserID",
+          "valueIdentifier": {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "12345"
+          }
+        },
+        {
+          "url": "http://example.org/inlinesubext/StructureDefinition/performer",
+          "extension": [
+            {
+              "url": "function",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "AUT"
+                  }
+                ]
+              }
+            },
+            {
+              "url": "actor",
+              "valueString": "Dr Bob"
+            }
+          ]
+        },
+        {
+          "url": "http://example.org/inlinesubext/StructureDefinition/performer",
+          "extension": [
+            {
+              "url": "function",
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                    "code": "DEV"
+                  }
+                ]
+              }
+            },
+            {
+              "url": "actor",
+              "valueString": "Scanner 1"
+            }
+          ]
+        }
+      ],
+      "who": {
+        "reference": "Patient/Bob"
+      }
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://dicom.nema.org/resources/ontology/DCM",
+        "code": "110122",
+        "display": "Login"
+      }
+    ]
+  },
+  "recorded": "2013-06-20T23:41:23Z",
+  "source": {
+    "observer": {
+      "reference": "Patient/Bob"
+    }
+  }
+}

--- a/validator/reslicing-inline-subextension-profile.json
+++ b/validator/reslicing-inline-subextension-profile.json
@@ -1,0 +1,115 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "InlineSubExtensionAuditEventProfile",
+  "url": "http://example.org/inlinesubext/StructureDefinition/InlineSubExtensionAuditEventProfile",
+  "version": "0.1.0",
+  "name": "InlineSubExtensionAuditEventProfile",
+  "status": "draft",
+  "description": "Re-slices a complex extension whose sub-extensions are defined inline, using a composite discriminator [value:url, pattern:extension('function').value]. The altid slice is a sibling that has no 'function' sub-extension, so the added discriminator legitimately does not resolve for it (R5 5.1.0.13).",
+  "fhirVersion": "5.0.0",
+  "kind": "resource",
+  "abstract": false,
+  "type": "AuditEvent",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/AuditEvent",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "AuditEvent.agent.extension",
+        "path": "AuditEvent.agent.extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            },
+            {
+              "type": "pattern",
+              "path": "extension('function').value"
+            }
+          ],
+          "ordered": false,
+          "rules": "open"
+        }
+      },
+      {
+        "id": "AuditEvent.agent.extension:altid",
+        "path": "AuditEvent.agent.extension",
+        "sliceName": "altid",
+        "min": 0,
+        "max": "1",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": [
+              "http://hl7.org/fhir/StructureDefinition/auditevent-AlternativeUserID"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "AuditEvent.agent.extension:performer",
+        "path": "AuditEvent.agent.extension",
+        "sliceName": "performer",
+        "min": 0,
+        "max": "*",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": [
+              "http://example.org/inlinesubext/StructureDefinition/performer"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "AuditEvent.agent.extension:performer/author",
+        "path": "AuditEvent.agent.extension",
+        "sliceName": "performer/author",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "AuditEvent.agent.extension:performer/author.extension:function",
+        "path": "AuditEvent.agent.extension.extension",
+        "sliceName": "function"
+      },
+      {
+        "id": "AuditEvent.agent.extension:performer/author.extension:function.value[x]",
+        "path": "AuditEvent.agent.extension.extension.value[x]",
+        "patternCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+              "code": "AUT"
+            }
+          ]
+        }
+      },
+      {
+        "id": "AuditEvent.agent.extension:performer/device",
+        "path": "AuditEvent.agent.extension",
+        "sliceName": "performer/device",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "AuditEvent.agent.extension:performer/device.extension:function",
+        "path": "AuditEvent.agent.extension.extension",
+        "sliceName": "function"
+      },
+      {
+        "id": "AuditEvent.agent.extension:performer/device.extension:function.value[x]",
+        "path": "AuditEvent.agent.extension.extension.value[x]",
+        "patternCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+              "code": "DEV"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds a validator test case for re-slicing a complex extension whose sub-extensions are defined inline.

The existing `R5.reslicing-extensions` case does not cover two situations, both of which arise whenever a profile re-slices an extension produced by the cross-version packages:

1. **A sibling slice that does not carry the discriminating element.** The profile slices `AuditEvent.agent.extension` on `[value:url, pattern:extension('function').value]`. The `performer` slice is re-sliced into `performer/author` (AUT) and `performer/device` (DEV); the sibling `altid` slice has no `function` sub-extension at all. R5 §5.1.0.13 permits this — a composite discriminator may designate an element that only some slices carry, and it contributes an empty value for the others.

2. **A sub-extension defined inline.** The extension definition declares its `function` and `actor` children inline, with no `type.profile`, so `extension(url)` has to match them by the fixed value of their `url` element. This is how every extension in `hl7.fhir.uv.xver-r5.r4` is built.

The expected outcome is an empty `OperationOutcome` — the instance is valid, and the profile should slice it cleanly.

### Note on current behaviour

This case **does not pass against current `master`** of `org.hl7.fhir.core`; it fails with `FHIRPATH_DISCRIMINATOR_CANT_FIND_EXTENSION`. It is submitted alongside a fix in `FHIRPathEngine.evaluateDefinition()` which makes it pass:

- hapifhir/org.hl7.fhir.core PR: *(link added once opened)*

This is the test case that was asked for in hapifhir/org.hl7.fhir.core#2279 but never supplied, which is why that PR was closed. Related: hapifhir/org.hl7.fhir.core#2138, hapifhir/org.hl7.fhir.core#2511.

I'm happy to adjust the fixture shape, naming, or expected outcome to whatever suits the suite better.