### PR TITLE
Validator: unversioned CodeSystem reference with an R5 CodeSystem loaded in an R4 context (context copy)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,1 @@
+* Add validator test case for an unversioned CodeSystem reference when hl7.fhir.uv.xver-r5.r4 brings an R5 version of a core CodeSystem into an R4 context (context copy in the Java validator)

--- a/validator/manifest.json
+++ b/validator/manifest.json
@@ -12645,6 +12645,21 @@
       "java": "java/R5.usage-context-gender-male-mismatch-base.json"
     },
     {
+      "name": "xver-encounter-status-r5cs",
+      "file": "xver-encounter-status-r5cs.json",
+      "description": "hl7.fhir.uv.xver-r5.r4 brings the R5 CodeSystem http://hl7.org/fhir/encounter-status (5.0.0) into an R4 context. A ValueSet that references the CodeSystem without a version must still be expanded with the R4 definition (4.0.1) of the core package, otherwise the R4-only code 'finished' is rejected. The Java validator validates with a copy of the base engine, which used to lose the preference for the core package definitions.",
+      "version": "4.0",
+      "module": "xver",
+      "tags": ["context-copy"],
+      "packages": ["hl7.fhir.uv.xver-r5.r4#0.1.0"],
+      "java": "java/R4.xver-encounter-status-r5cs-base.json",
+      "profile": {
+        "source": "xver-encounter-status-r5cs-sd.json",
+        "supporting": ["xver-encounter-status-r5cs-vs.json"],
+        "java": "java/R4.xver-encounter-status-r5cs-profile.json"
+      }
+    },
+    {
       "name": "zzz",
       "file": "zzz.json",
       "description": "hack for close ups",

--- a/validator/outcomes/java/R4.xver-encounter-status-r5cs-base.json
+++ b/validator/outcomes/java/R4.xver-encounter-status-r5cs-base.json
@@ -1,0 +1,3 @@
+{
+  "resourceType" : "OperationOutcome"
+}

--- a/validator/outcomes/java/R4.xver-encounter-status-r5cs-profile.json
+++ b/validator/outcomes/java/R4.xver-encounter-status-r5cs-profile.json
@@ -1,0 +1,17 @@
+
+{
+  "resourceType" : "OperationOutcome",
+  "issue" : [{
+    "extension" : [{
+      "url" : "http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-context",
+      "valueString" : "http://hl7.org/fhir/test/StructureDefinition/xver-encounter-status-r5cs|1.0.0"
+    }],
+    "severity" : "information",
+    "code" : "business-rule",
+    "details" : {
+      "text" : "Reference to draft CodeSystem http://hl7.org/fhir/encounter-status|4.0.1"
+    },
+    "diagnostics" : "[8,24]",
+    "expression" : ["Encounter.status"]
+  }]
+}

--- a/validator/xver-encounter-status-r5cs-sd.json
+++ b/validator/xver-encounter-status-r5cs-sd.json
@@ -1,0 +1,28 @@
+{
+  "resourceType" : "StructureDefinition",
+  "id" : "xver-encounter-status-r5cs",
+  "url" : "http://hl7.org/fhir/test/StructureDefinition/xver-encounter-status-r5cs",
+  "version" : "1.0.0",
+  "name" : "XverEncounterStatusR5CS",
+  "status" : "active",
+  "fhirVersion" : "4.0.1",
+  "kind" : "resource",
+  "abstract" : false,
+  "type" : "Encounter",
+  "baseDefinition" : "http://hl7.org/fhir/StructureDefinition/Encounter",
+  "derivation" : "constraint",
+  "differential" : {
+    "element" : [{
+      "id" : "Encounter",
+      "path" : "Encounter"
+    },
+    {
+      "id" : "Encounter.status",
+      "path" : "Encounter.status",
+      "binding" : {
+        "strength" : "required",
+        "valueSet" : "http://hl7.org/fhir/test/ValueSet/xver-encounter-status-r5cs"
+      }
+    }]
+  }
+}

--- a/validator/xver-encounter-status-r5cs-vs.json
+++ b/validator/xver-encounter-status-r5cs-vs.json
@@ -1,0 +1,20 @@
+{
+  "resourceType" : "ValueSet",
+  "id" : "xver-encounter-status-r5cs",
+  "url" : "http://hl7.org/fhir/test/ValueSet/xver-encounter-status-r5cs",
+  "version" : "1.0.0",
+  "name" : "XverEncounterStatusR5CS",
+  "status" : "active",
+  "description" : "R4 codes of the encounter status. The CodeSystem is referenced without a version, so the R4 core definition (4.0.1) is expected to be used, not the R5 one (5.0.0) that hl7.fhir.uv.xver-r5.r4 brings into the context.",
+  "compose" : {
+    "include" : [{
+      "system" : "http://hl7.org/fhir/encounter-status",
+      "concept" : [{
+        "code" : "in-progress"
+      },
+      {
+        "code" : "finished"
+      }]
+    }]
+  }
+}

--- a/validator/xver-encounter-status-r5cs.json
+++ b/validator/xver-encounter-status-r5cs.json
@@ -1,0 +1,14 @@
+{
+  "resourceType" : "Encounter",
+  "id" : "xver-encounter-status",
+  "text" : {
+    "status" : "generated",
+    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>Finished inpatient encounter</p></div>"
+  },
+  "status" : "finished",
+  "class" : {
+    "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code" : "IMP",
+    "display" : "inpatient encounter"
+  }
+}


### PR DESCRIPTION
New validator test case `xver-encounter-status-r5cs` (R4, module `xver`, tag `context-copy`).

`hl7.fhir.uv.xver-r5.r4#0.1.0` brings the R5 version (5.0.0) of `http://hl7.org/fhir/encounter-status` into an R4 context, next to the 4.0.1 definition of hl7.fhir.r4.core. A ValueSet that references that CodeSystem without a version must be expanded with the R4 definition of the core (master) package, so the R4-only code `finished` is valid.

`ValidationTests` validates every case with a copy of the base engine (`CLONE = true`). The copy of the context loses the `packages` map (BaseWorkerContext) and the `masterDefinitions` (CanonicalResourceManager), so the unversioned reference falls back to the latest version and the profile validation currently fails:

```
error/code-invalid @ Encounter.status.code: Unknown code 'finished' in the CodeSystem 'http://hl7.org/fhir/encounter-status' version '5.0.0'
error/code-invalid @ Encounter.status: The value provided ('finished') was not found in the value set 'XverEncounterStatusR5CS' ...
```

Expected outcome (with the fix in the companion core PR): no errors, only the informational "Reference to draft CodeSystem http://hl7.org/fhir/encounter-status|4.0.1" note, which shows the R4 definition is used.

The base validation (core Encounter profile) passes with and without the fix, because the core ValueSet resolves through its own package.

Companion PR in org.hl7.fhir.core: hapifhir/org.hl7.fhir.core#2623. Run only this case with `-DincludedValidationTags=context-copy`.

Background: reported against matchbox in https://github.com/ahdis/matchbox/issues/538 (matchbox validates on copies of a base engine like the validator service does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)